### PR TITLE
Fix: Corrected variable declarations in CANCEL_PRINT

### DIFF
--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -52,9 +52,11 @@ description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
   ##### get user parameters or use default #####
-  {% set allow_park = False if printer['gcode_macro _CLIENT_VARIABLE'] is not defined
-                 else False if printer['gcode_macro _CLIENT_VARIABLE'].park_at_cancel is not defined
-                 else True  if printer['gcode_macro _CLIENT_VARIABLE'].park_at_cancel|lower == 'true' 
+  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
+  {% set allow_park = False if not macro_found
+                 else False if client.park_at_cancel is not defined
+                 else True  if client.park_at_cancel|lower == 'true'
                  else False %}
   {% set retract      = 5.0  if not macro_found else client.cancel_retract|default(5.0)|abs %}
   {% set sp_retract   = 2100 if not macro_found else client.speed_retract|default(35) * 60 %}


### PR DESCRIPTION
The current implement appears to be a broken copy & paste of other code. It's missing the `macro_found` variable, as well as using an inconsistent method to determine the `allow_park` value.

This update brings `CANCEL_PRINT` back inline with the other macros, and restoring the missing expected variables