### PR TITLE
Refactor duplicated code into separate EXTRUDE/RETRACT macros

### DIFF
--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -86,25 +86,9 @@ gcode:
   {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
   {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
-  {% set use_fw_retract = False if not macro_found
-                     else False if client.use_fw_retract is not defined
-                     else True  if client.use_fw_retract|lower == 'true' and printer.firmware_retraction is defined
-                     else False %}
-  {% set unretract      = 1.0  if not macro_found else client.unretract|default(1.0)|abs %}
-  {% set sp_unretract   = 2100 if not macro_found else client.speed_unretract|default(35) * 60 %}
   {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
   ##### end of definitions #####
-  {% if printer.extruder.can_extrude %}
-    {% if use_fw_retract %}
-      G11
-    {% else %}
-      M83
-      G1 E{unretract} F{sp_unretract}
-      {% if printer.gcode_move.absolute_extrude %} M82 {% endif %}
-    {% endif %}
-  {% else %}
-    {action_respond_info("Extruder not hot enough %s" % use_fw_retract)}
-  {% endif %}
+  _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
 
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]
@@ -166,4 +150,39 @@ gcode:
     {% if not printer.gcode_move.absolute_coordinates %} G91 {% endif %}
   {% else %}
     {action_respond_info("Printer not homed")}
+  {% endif %}
+
+
+[gcode_macro _CLIENT_EXTRUDE]
+description: Extrudes, if the extruder is hot enough
+gcode:
+  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
+  {% set use_fw_retract = False if not macro_found
+                     else False if client.use_fw_retract is not defined
+                     else True  if client.use_fw_retract|lower == 'true' and printer.firmware_retraction is defined
+                     else False %}
+
+  {% set length = (params.LENGTH|float) if params.LENGTH is defined
+             else 1.0 if not macro_found
+             else client.unretract|default(1.0) %}
+
+  {% set speed = params.SPEED if params.SPEED is defined
+            else 35 if not macro_found
+            else client.speed_unretract|default(35) %}
+
+  {% set absolute_extrude = printer.gcode_move.absolute_extrude %}
+
+  {% if printer.extruder.can_extrude %}
+    {% if use_fw_retract %}
+      G11
+    {% else %}
+      M83
+      G1 E{length} F{(speed|float|abs) * 60}
+      {% if absolute_extrude %}
+        M82
+      {% endif %}
+    {% endif %}
+  {% else %}
+    {action_respond_info("Extruder not hot enough")}
   {% endif %}

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -57,16 +57,9 @@ gcode:
                  else True  if client.park_at_cancel|lower == 'true'
                  else False %}
   {% set retract      = 5.0  if not macro_found else client.cancel_retract|default(5.0)|abs %}
-  {% set sp_retract   = 2100 if not macro_found else client.speed_retract|default(35) * 60 %}
   ##### end of definitions #####
   {% if not printer.pause_resume.is_paused and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {% endif %}
-  {% if printer.extruder.can_extrude %}
-    M83
-    G1 E-{retract} F{sp_retract}
-    {% if printer.gcode_move.absolute_extrude %} M82 {% endif %}
-  {% else %}
-    {action_respond_info("Extruder not hot enough")}
-  {% endif %}
+  _CLIENT_RETRACT LENGTH={retract}
   TURN_OFF_HEATERS
   M106 S0
   CANCEL_PRINT_BASE
@@ -105,12 +98,6 @@ gcode:
   {% set custom_park_x  = 0.0 if not macro_found else client.custom_park_x|default(0.0) %}
   {% set custom_park_y  = 0.0 if not macro_found else client.custom_park_y|default(0.0) %}
   {% set park_dz        = 2.0 if not macro_found else client.custom_park_dz|default(2.0)|abs %}
-  {% set use_fw_retract = False if not macro_found
-                     else False if client.use_fw_retract is not defined
-                     else True  if client.use_fw_retract|lower == 'true' and printer.firmware_retraction is defined
-                     else False %}
-  {% set retract      = 1.0  if not macro_found else client.retract|default(1.0)|abs %}
-  {% set sp_retract   = 2100 if not macro_found else client.speed_retract|default(35) * 60 %}
   {% set sp_hop       = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
   {% set sp_move      = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
   ##### get config and toolhead values #####
@@ -132,17 +119,7 @@ gcode:
              else 0.0            if round_bed
              else (max.y - 5.0) %}
   ##### end of definitions #####
-  {% if printer.extruder.can_extrude %}
-    {% if use_fw_retract %}
-      G10
-    {% else %}
-      M83
-      G1 E-{retract} F{sp_retract}
-      {% if printer.gcode_move.absolute_extrude %} M82 {% endif %}
-    {% endif %}
-  {% else %}
-    {action_respond_info("Extruder not hot enough")}
-  {% endif %}
+  _CLIENT_RETRACT
   {% if "xyz" in printer.toolhead.homed_axes %}
     G90
     G1 Z{z_park} F{sp_hop}
@@ -175,7 +152,11 @@ gcode:
 
   {% if printer.extruder.can_extrude %}
     {% if use_fw_retract %}
-      G11
+      {% if length < 0 %}
+        G10
+      {% else %}
+        G11
+      {% endif %}
     {% else %}
       M83
       G1 E{length} F{(speed|float|abs) * 60}
@@ -186,3 +167,20 @@ gcode:
   {% else %}
     {action_respond_info("Extruder not hot enough")}
   {% endif %}
+
+
+[gcode_macro _CLIENT_RETRACT]
+description: Retracts, if the extruder is hot enough
+gcode:
+  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
+
+  {% set length = (params.LENGTH|float) if params.LENGTH is defined
+             else 1.0 if not macro_found
+             else client.retract|default(1.0) %}
+
+  {% set speed = params.SPEED if params.SPEED is defined
+            else 35 if not macro_found
+            else client.speed_retract|default(35) %}
+
+  _CLIENT_EXTRUDE LENGTH=-{length|float|abs} SPEED={speed|float|abs}

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -10,10 +10,10 @@
 ## copy the following macro to your printer.cfg (outside of mainsail.cfg)
 
 #[gcode_macro _CLIENT_VARIABLE]
-#variable_use_custom_pos  : False ; use custom park coordinates for x,y [True/False] 
+#variable_use_custom_pos  : False ; use custom park coordinates for x,y [True/False]
 #variable_custom_park_x   : 0.0   ; custom x position; value must be within your defined min and max of X
 #variable_custom_park_y   : 0.0   ; custom y position; value must be within your defined min and max of Y
-#variable_custom_park_dz  : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position 
+#variable_custom_park_dz  : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
 #variable_retract         : 1.0   ; the value to retract while PAUSE
 #variable_cancel_retract  : 5.0   ; the value to retract while CANCEL_PRINT
 #variable_speed_retract   : 35.0  ; retract speed in mm/s
@@ -23,7 +23,7 @@
 #variable_speed_move      : 100.0 ; move speed in mm/s
 #variable_park_at_cancel  : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True,False]
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-#variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False] 
+#variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
 #gcode:
 
 ## After you uncomment it add your custom values
@@ -89,7 +89,7 @@ gcode:
   {% set use_fw_retract = False if not macro_found
                      else False if client.use_fw_retract is not defined
                      else True  if client.use_fw_retract|lower == 'true' and printer.firmware_retraction is defined
-                     else False %} 
+                     else False %}
   {% set unretract      = 1.0  if not macro_found else client.unretract|default(1.0)|abs %}
   {% set sp_unretract   = 2100 if not macro_found else client.speed_unretract|default(35) * 60 %}
   {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
@@ -104,8 +104,8 @@ gcode:
     {% endif %}
   {% else %}
     {action_respond_info("Extruder not hot enough %s" % use_fw_retract)}
-  {% endif %}  
-  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}  
+  {% endif %}
+  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
 
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT
@@ -116,7 +116,7 @@ gcode:
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set use_custom     = False if not macro_found
                      else False if client.use_custom_pos is not defined
-                     else True  if client.use_custom_pos|lower == 'true' 
+                     else True  if client.use_custom_pos|lower == 'true'
                      else False %}
   {% set custom_park_x  = 0.0 if not macro_found else client.custom_park_x|default(0.0) %}
   {% set custom_park_y  = 0.0 if not macro_found else client.custom_park_y|default(0.0) %}
@@ -133,14 +133,14 @@ gcode:
   {% set act = printer.toolhead.position %}
   {% set max = printer.toolhead.axis_maximum %}
   {% set cone = printer.toolhead.cone_start_z|default(max.z) %} ; height as long the toolhead can reach max and min of an delta
-  {% set round_bed = True if printer.configfile.settings.printer.kinematics is in ['delta','polar','rotary_delta','winch'] 
+  {% set round_bed = True if printer.configfile.settings.printer.kinematics is in ['delta','polar','rotary_delta','winch']
                 else False %}
   ##### define park position #####
   {% set z_min = params.Z_MIN|default(0)|float %}
   {% set z_park = [[(act.z + park_dz), z_min]|max, max.z]|min %}
   {% set x_park = params.X       if params.X is defined
              else custom_park_x  if use_custom
-             else 0.0            if round_bed 
+             else 0.0            if round_bed
              else (max.x - 5.0) %}
   {% set y_park = params.Y       if params.Y is defined
              else custom_park_y  if use_custom


### PR DESCRIPTION
Refactored the existing code to remove repetition, and make ongoing maintenance easier by improving readability, and providing a single point where updates need to be made. It also allows for code reuse in custom macros by the end user.

The EXTRUDE gcode is an almost identical implementation of the original, whereas RETRACT mostly leverages the functionality in EXTRUDE.

An update I would like to make, but not sure how (if it's possible) is to eliminate the speed param management in RETRACT, and have this parameter (if supplied) automagically passed through to EXTRUDE. I wasn't sure of the cleanest/best way to do that.