### PR TITLE
Pause at layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is the new location of the macros and settings provided by the Mainsail tea
   - That is helpful to direct the use of the PAUSE macro in your M600 (see the mainsail.cfg for an example)
 - Customization via a single macro that contains all allowed variables
 - Additional custom variables for stuff like extra retract at CANCEL_PRINT.
+- "Pause at next Layer" and "Pause at Layer #" 
 
 ### Why have we decided to use a dedicated repo?
 There are 2 main reasons for that decision
@@ -95,3 +96,26 @@ variable_custom_park_y   : 10.0  ; custom y position; value must be within your 
 gcode:
 ``` 
 You can also uncomment all variables if you like. The values are the same as the used default.
+
+### New Feature: "Pause at next Layer" and "Pause at Layer #"
+This is based on a idea of Pedro Lamas. It let you add a Pause either at the next layer change or if you reach a given layer.
+
+First you need to prepare your slicer as described in https://github.com/Klipper3d/klipper/pull/5726
+
+If you done that you can either use 
+```
+SET_PAUSE_NEXT_LAYER [MACRO=name]
+```
+to get execute the given GCODE macro at the next layer change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
+
+Or use 
+```
+SET_PAUSE_AT_LAYER LAYER=number [MACRO=name]
+```
+to get execute the given GCODE macro at the given LAYER number change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
+
+To remove the "Pause at Layer" simple send
+```
+SET_PAUSE_AT_LAYER LAYER=number [MACRO=name]
+```
+Both will clear after execution.

--- a/README.md
+++ b/README.md
@@ -98,24 +98,24 @@ gcode:
 You can also uncomment all variables if you like. The values are the same as the used default.
 
 ### New Feature: "Pause at next Layer" and "Pause at Layer #"
-This is based on a idea of Pedro Lamas. It let you add a Pause either at the next layer change or if you reach a given layer.
+This is based on a idea of Pedro Lamas. It let you add a Pause at the next layer change or if you reach a specific layer number.
 
 First you need to prepare your slicer as described in https://github.com/Klipper3d/klipper/pull/5726
 
 If you done that you can either use 
 ```
-SET_PAUSE_NEXT_LAYER [MACRO=name]
+SET_PAUSE_NEXT_LAYER [MACRO=<name>]
 ```
 to get execute the given GCODE macro at the next layer change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
 
 Or use 
 ```
-SET_PAUSE_AT_LAYER LAYER=number [MACRO=name]
+SET_PAUSE_AT_LAYER LAYER=<number> [MACRO=<name>]
 ```
 to get execute the given GCODE macro at the given LAYER number change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
 
 To remove the "Pause at Layer" simple send
 ```
-SET_PAUSE_AT_LAYER LAYER=number [MACRO=name]
+SET_PAUSE_AT_LAYER
 ```
 Both will clear after execution.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are 2 main reasons for that decision
 
 ### How to install
 We currently do not provide an installer and we might never do. But doing it is simple copy and paste a few commands in an ssh terminal.
-The instructions assume that you have a up to data and working moonraker installation. If not start with updating your moonraker first.
+The instructions assume that you have an up to data and working moonraker installation. If not start with updating your moonraker first.
 
 ```
 cd ~
@@ -28,7 +28,7 @@ git clone https://github.com/mainsail-crew/mainsail-config.git
 ln -sf ~/mainsail-config/mainsail.cfg ~/printer_data/config/mainsail.cfg
 ```
 ### Add updater section
-You need to update your moonraker.conf to get alway the latest version.
+You need to update your moonraker.conf to alway get the latest version.
 
 Either open your moonraker.conf and add 
 ```
@@ -45,7 +45,7 @@ You can also link and include the prepared file to your moonraker.conf. ssh in y
 ```
 ln -sf ~/mainsail-config/mainsail-moonraker-update.conf ~/printer_data/config/mainsail-moonraker-update.conf
 ```
-than open your moonraker.conf and add
+then open your moonraker.conf and add
 ```
 [include mainsail-moonraker-update.conf]
 ```
@@ -61,7 +61,7 @@ to your printer.cfg file. Be aware the file will show up as read only. This was 
 
 ### How to customize your settings
 ##### Different virtual sd card location or a different on_error_gcode
-for that simple copy the [virtual_sdcard] block from the mainsail.cfg and simple place it below your include. The result should look similar to:
+for that simply copy the [virtual_sdcard] block from the mainsail.cfg and simple place it below your include. The result should look similar to:
 ```
 [include mainsail.cfg]
 
@@ -95,7 +95,7 @@ variable_custom_park_y   : 10.0  ; custom y position; value must be within your 
 #variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False] 
 gcode:
 ``` 
-You can also uncomment all variables if you like. The values are the same as the used default.
+You can also uncomment all variables if you like. The values are the same as the user default.
 
 ### New Feature: "Pause at next Layer" and "Pause at Layer #"
 This is based on a idea of Pedro Lamas. It let you add a Pause at the next layer change or if you reach a specific layer number.

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -1,4 +1,4 @@
-## Mainsail klipper macro definitions
+## Client klipper macro definitions
 ##
 ## Copyright (C) 2022 Alex Zellner <alexander.zellner@googlemail.com>
 ##

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -45,6 +45,7 @@ on_error_gcode: CANCEL_PRINT
 
 [display_status]
 
+# Usage: CANCEL_PRINT
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
@@ -71,6 +72,7 @@ gcode:
   M106 S0
   CANCEL_PRINT_BASE
 
+# Usage: PAUSE [X=<value>] [Y=<value>] [Z_MIN=<value>]
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
@@ -78,6 +80,7 @@ gcode:
   PAUSE_BASE
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
 
+# Usage: RESUME [VELOCITY=<value>]
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: RESUME_BASE
@@ -107,12 +110,12 @@ gcode:
   {% endif %}  
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
 
+# Usage: SET_PAUSE_NEXT_LAYER [MACRO=<name>]
 [gcode_macro SET_PAUSE_NEXT_LAYER]
 description: Enable a pause if the next layer is reached
 gcode: SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable':True, 'call':params.MACRO|default("PAUSE")}}"
 
-# Use SET_PAUSE_AT_LAYER LAYER=50 to set a pause when layer 50 is reached
-# Use SET_PAUSE_AT_LAYER          to remove a PAUSE_AT_LAYER
+# Usage: SET_PAUSE_AT_LAYER [LAYER=<number>] [MACRO=<name>]
 [gcode_macro SET_PAUSE_AT_LAYER]
 description: Enable\disable a pause if a given layer number is reached
 gcode:
@@ -122,6 +125,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer':0, 'call':"PAUSE"}}"
   {% endif %}
 
+# Usage: SET_PRINT_STATS_INFO [TOTAL_LAYER=<total_layer_count>] [CURRENT_LAYER= <current_layer>]
 [gcode_macro SET_PRINT_STATS_INFO]
 rename_existing: SET_PRINT_STATS_INFO_BASE
 description: Overwrite, to get pause_next_layer and pause_at_layer feature 

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -23,7 +23,7 @@
 #variable_speed_move      : 100.0 ; move speed in mm/s
 #variable_park_at_cancel  : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True,False]
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-#variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False] 
+#variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
 #gcode:
 
 ## After you uncomment it add your custom values
@@ -103,9 +103,41 @@ gcode:
       {% if printer.gcode_move.absolute_extrude %} M82 {% endif %}
     {% endif %}
   {% else %}
-    {action_respond_info("Extruder not hot enough %s" % use_fw_retract)}
+    {action_respond_info("Extruder not hot enough")}
   {% endif %}  
-  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}  
+  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+
+[gcode_macro SET_PAUSE_NEXT_LAYER]
+description: Enable a pause if the next layer is reached
+gcode: SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable':True, 'call':params.MACRO|default("PAUSE")}}"
+
+# Use SET_PAUSE_AT_LAYER LAYER=50 to set a pause when layer 50 is reached
+# Use SET_PAUSE_AT_LAYER          to remove a PAUSE_AT_LAYER
+[gcode_macro SET_PAUSE_AT_LAYER]
+description: Enable\disable a pause if a given layer number is reached
+gcode:
+  {% if params.LAYER is defined %}
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': True, 'layer':params.LAYER|int, 'call':params.MACRO|default("PAUSE")}}"
+  {% else %}
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer':0, 'call':"PAUSE"}}"
+  {% endif %}
+
+[gcode_macro SET_PRINT_STATS_INFO]
+rename_existing: SET_PRINT_STATS_INFO_BASE
+description: Overwrite, to get pause_next_layer and pause_at_layer feature 
+variable_pause_next_layer: {'enable':False, 'call':"PAUSE"}
+variable_pause_at_layer  : {'enable':False, 'layer':0, 'call':"PAUSE"}
+gcode:
+  {% if pause_next_layer.enable %}
+    {action_respond_info("%s, forced by pause_next_layer" % pause_next_layer.call)}
+    {pause_next_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable': False, 'call':"PAUSE"}}"
+  {% elif pause_at_layer.enable and params.CURRENT_LAYER is defined and params.CURRENT_LAYER|int == pause_at_layer.layer %}
+    {action_respond_info("%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer))}
+    {pause_at_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer': 0, 'call':"PAUSE"}}"
+  {% endif %}
+  SET_PRINT_STATS_INFO_BASE {rawparams}  
 
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -117,7 +117,7 @@ gcode: SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer V
 
 # Usage: SET_PAUSE_AT_LAYER [LAYER=<number>] [MACRO=<name>]
 [gcode_macro SET_PAUSE_AT_LAYER]
-description: Enable\disable a pause if a given layer number is reached
+description: Enable/disable a pause if a given layer number is reached
 gcode:
   {% if params.LAYER is defined %}
     SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': True, 'layer':params.LAYER|int, 'call':params.MACRO|default("PAUSE")}}"

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -83,7 +83,41 @@ gcode:
   ##### end of definitions #####
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  
+# Usage: SET_PAUSE_NEXT_LAYER [MACRO=<name>]
+[gcode_macro SET_PAUSE_NEXT_LAYER]
+description: Enable a pause if the next layer is reached
+gcode: SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable':True, 'call':params.MACRO|default("PAUSE")}}"
 
+# Usage: SET_PAUSE_AT_LAYER [LAYER=<number>] [MACRO=<name>]
+[gcode_macro SET_PAUSE_AT_LAYER]
+description: Enable/disable a pause if a given layer number is reached
+gcode:
+  {% if params.LAYER is defined %}
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': True, 'layer':params.LAYER|int, 'call':params.MACRO|default("PAUSE")}}"
+  {% else %}
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer':0, 'call':"PAUSE"}}"
+  {% endif %}
+
+# Usage: SET_PRINT_STATS_INFO [TOTAL_LAYER=<total_layer_count>] [CURRENT_LAYER= <current_layer>]
+[gcode_macro SET_PRINT_STATS_INFO]
+rename_existing: SET_PRINT_STATS_INFO_BASE
+description: Overwrite, to get pause_next_layer and pause_at_layer feature 
+variable_pause_next_layer: {'enable':False, 'call':"PAUSE"}
+variable_pause_at_layer  : {'enable':False, 'layer':0, 'call':"PAUSE"}
+gcode:
+  {% if pause_next_layer.enable %}
+    {action_respond_info("%s, forced by pause_next_layer" % pause_next_layer.call)}
+    {pause_next_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable': False, 'call':"PAUSE"}}"
+  {% elif pause_at_layer.enable and params.CURRENT_LAYER is defined and params.CURRENT_LAYER|int == pause_at_layer.layer %}
+    {action_respond_info("%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer))}
+    {pause_at_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
+    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer': 0, 'call':"PAUSE"}}"
+  {% endif %}
+  SET_PRINT_STATS_INFO_BASE {rawparams}
+  
+##### internal use #####
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT
 gcode:
@@ -128,8 +162,7 @@ gcode:
   {% else %}
     {action_respond_info("Printer not homed")}
   {% endif %}
-
-
+  
 [gcode_macro _CLIENT_EXTRUDE]
 description: Extrudes, if the extruder is hot enough
 gcode:
@@ -167,7 +200,6 @@ gcode:
   {% else %}
     {action_respond_info("Extruder not hot enough")}
   {% endif %}
-
 
 [gcode_macro _CLIENT_RETRACT]
 description: Retracts, if the extruder is hot enough


### PR DESCRIPTION
These features are based on the idea of @pedrolamas.

You can use it in combination with the https://github.com/Klipper3d/klipper/pull/5726 to easily do a PAUSE or M600 either at the next layer change or a defined Layer#

Signed-off-by: Alex Zellner <alexander.zellner@googlemail.com>