### PR TITLE
Renames mainsail.cfg to client.cfg

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -4,10 +4,10 @@
 ##
 ## This file may be distributed under the terms of the GNU GPLv3 license
 
-## add [include mainsail.cfg] to your printer.cfg
+## add [include client.cfg] to your printer.cfg
 
 ## Customization:
-## copy the following macro to your printer.cfg (outside of mainsail.cfg)
+## copy the following macro to your printer.cfg (outside of client.cfg)
 
 #[gcode_macro _CLIENT_VARIABLE]
 #variable_use_custom_pos  : False ; use custom park coordinates for x,y [True/False]

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -1,0 +1,1 @@
+./client.cfg

--- a/mainsail.cfg
+++ b/mainsail.cfg
@@ -135,17 +135,18 @@ gcode:
   {% set custom_park_x  = 0.0 if not macro_found else client.custom_park_x|default(0.0) %}
   {% set custom_park_y  = 0.0 if not macro_found else client.custom_park_y|default(0.0) %}
   {% set park_dz        = 2.0 if not macro_found else client.custom_park_dz|default(2.0)|abs %}
-  {% set sp_hop       = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
-  {% set sp_move      = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
+  {% set sp_hop         = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
+  {% set sp_move        = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
   ##### get config and toolhead values #####
-  {% set act = printer.toolhead.position %}
-  {% set max = printer.toolhead.axis_maximum %}
-  {% set cone = printer.toolhead.cone_start_z|default(max.z) %} ; height as long the toolhead can reach max and min of an delta
+  {% set origion   = printer.gcode_move.homing_origin %}
+  {% set act       = printer.gcode_move.gcode_position %}
+  {% set max       = printer.toolhead.axis_maximum %}
+  {% set cone      = printer.toolhead.cone_start_z|default(max.z) %} ; height as long the toolhead can reach max and min of an delta
   {% set round_bed = True if printer.configfile.settings.printer.kinematics is in ['delta','polar','rotary_delta','winch']
                 else False %}
   ##### define park position #####
   {% set z_min = params.Z_MIN|default(0)|float %}
-  {% set z_park = [[(act.z + park_dz), z_min]|max, max.z]|min %}
+  {% set z_park = [[(act.z + park_dz), z_min]|max, (max.z - origion.z)]|min %}
   {% set x_park = params.X       if params.X is defined
              else custom_park_x  if use_custom
              else 0.0            if round_bed


### PR DESCRIPTION
In the past few days I've been discussing with @zellneralex and @meteyou on how this can be used in non-Mainsail ensuring we keep this as "source of truth" as the best Klipper base config around!

The changes discussed and implemented here are as follow:

- rename the mainsail.cfg to client.cfg and rename all mainsail to client in the config file.
- add a symbolic link from client.cfg to mainsail.cfg to ensure existing clients do not get broken.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>