### PR TITLE
Feat new park position for CANCEL_PRINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is the new location of the macros and settings provided by the Mainsail tea
   - Round beds 0:Ymax
   - Square beds Xmax:Ymax
   - User Position
+  - User can specify an differnt position for PAUSE and CANCEL_PRINT
 - PAUSE now supports option input parameters [X,Y,Z_MIN]
   - That is helpful to direct the use of the PAUSE macro in your M600 (see the mainsail.cfg for an example)
 - Customization via a single macro that contains all allowed variables
@@ -94,8 +95,39 @@ variable_custom_park_y   : 10.0  ; custom y position; value must be within your 
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
 #variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False] 
 gcode:
-``` 
+```
 You can also uncomment all variables if you like. The values are the same as the user default.
+
+##### Differnent park positon
+The following descrips how to setup a custom position for CANCEL_PRINT and PAUSE. As an example we asume the bed has asize of (300x300mm) and we want:
+- Position for CANCEL_PRINT: back right (295x295 mm) 
+- Position for PAUSE       : front left (10x10 mm)
+
+First copy the complete _CLIENT_VARIABLE macro from the mainsail.cfg and place it below your mainsail include. After that uncomment the needed variables or all. The values are the same as the default.
+After that we need to enter the needed values. See the result below:
+```
+[include mainsail.cfg]
+
+[gcode_macro _CLIENT_VARIABLE]
+variable_use_custom_pos   : True  ; use custom park coordinates for x,y [True/False]
+variable_custom_park_x    : 10.0  ; custom x position; value must be within your defined min and max of X
+variable_custom_park_y    : 10.0  ; custom y position; value must be within your defined min and max of Y
+variable_custom_park_dz   : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
+variable_retract          : 1.0   ; the value to retract while PAUSE
+variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
+variable_speed_retract    : 35.0  ; retract speed in mm/s
+variable_unretract        : 1.0   ; the value to unretract while RESUME
+variable_speed_unretract  : 35.0  ; unretract speed in mm/s
+variable_speed_hop        : 15.0  ; z move speed in mm/s
+variable_speed_move       : 100.0 ; move speed in mm/s
+variable_park_at_cancel   : True  ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
+variable_park_at_cancel_x : 295.0 ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+variable_park_at_cancel_y : 295.0 ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+# !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
+variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
+gcode:
+```
+This way insures that older configs still work as before.
 
 ### New Feature: "Pause at next Layer" and "Pause at Layer #"
 This is based on a idea of Pedro Lamas. It let you add a Pause at the next layer change or if you reach a specific layer number.

--- a/client.cfg
+++ b/client.cfg
@@ -3,12 +3,22 @@
 ## Copyright (C) 2022 Alex Zellner <alexander.zellner@googlemail.com>
 ##
 ## This file may be distributed under the terms of the GNU GPLv3 license
-
-## add [include client.cfg] to your printer.cfg
-
+##
+## !!! This file is read-only. Maybe the used editor indicates that. !!!
+##
 ## Customization:
-## copy the following macro to your printer.cfg (outside of client.cfg)
-
+##   1) copy the gcode_macro _CLIENT_VARIABLE (see below) to your printer.cfg
+##   2) remove the comment mark (#) from all lines
+##   3) change any value in there to your needs
+##
+## Use the PAUSE macro direct in your M600:
+##  e.g. with a different park position front left and a minimal height of 50 
+##    [gcode_macro M600]
+##    description: Filament change
+##    gcode: PAUSE X=10 Y=10 Z_MIN=50
+##  Z_MIN will park the toolhead at a minimum of 50 mm above to bed to make it easier for you to swap filament.
+##
+## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]
 #variable_use_custom_pos  : False ; use custom park coordinates for x,y [True/False]
 #variable_custom_park_x   : 0.0   ; custom x position; value must be within your defined min and max of X

--- a/client.cfg
+++ b/client.cfg
@@ -148,7 +148,7 @@ gcode:
   {% set sp_hop         = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
   {% set sp_move        = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
   ##### get config and toolhead values #####
-  {% set origion   = printer.gcode_move.homing_origin %}
+  {% set origin   = printer.gcode_move.homing_origin %}
   {% set act       = printer.gcode_move.gcode_position %}
   {% set max       = printer.toolhead.axis_maximum %}
   {% set cone      = printer.toolhead.cone_start_z|default(max.z) %} ; height as long the toolhead can reach max and min of an delta
@@ -156,7 +156,7 @@ gcode:
                 else False %}
   ##### define park position #####
   {% set z_min = params.Z_MIN|default(0)|float %}
-  {% set z_park = [[(act.z + park_dz), z_min]|max, (max.z - origion.z)]|min %}
+  {% set z_park = [[(act.z + park_dz), z_min]|max, (max.z - origin.z)]|min %}
   {% set x_park = params.X       if params.X is defined
              else custom_park_x  if use_custom
              else 0.0            if round_bed

--- a/client.cfg
+++ b/client.cfg
@@ -20,32 +20,23 @@
 ##
 ## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]
-#variable_use_custom_pos  : False ; use custom park coordinates for x,y [True/False]
-#variable_custom_park_x   : 0.0   ; custom x position; value must be within your defined min and max of X
-#variable_custom_park_y   : 0.0   ; custom y position; value must be within your defined min and max of Y
-#variable_custom_park_dz  : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
-#variable_retract         : 1.0   ; the value to retract while PAUSE
-#variable_cancel_retract  : 5.0   ; the value to retract while CANCEL_PRINT
-#variable_speed_retract   : 35.0  ; retract speed in mm/s
-#variable_unretract       : 1.0   ; the value to unretract while RESUME
-#variable_speed_unretract : 35.0  ; unretract speed in mm/s
-#variable_speed_hop       : 15.0  ; z move speed in mm/s
-#variable_speed_move      : 100.0 ; move speed in mm/s
-#variable_park_at_cancel  : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True,False]
+#variable_use_custom_pos   : False ; use custom park coordinates for x,y [True/False]
+#variable_custom_park_x    : 0.0   ; custom x position; value must be within your defined min and max of X
+#variable_custom_park_y    : 0.0   ; custom y position; value must be within your defined min and max of Y
+#variable_custom_park_dz   : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
+#variable_retract          : 1.0   ; the value to retract while PAUSE
+#variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
+#variable_speed_retract    : 35.0  ; retract speed in mm/s
+#variable_unretract        : 1.0   ; the value to unretract while RESUME
+#variable_speed_unretract  : 35.0  ; unretract speed in mm/s
+#variable_speed_hop        : 15.0  ; z move speed in mm/s
+#variable_speed_move       : 100.0 ; move speed in mm/s
+#variable_park_at_cancel   : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
+#variable_park_at_cancel_x : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+#variable_park_at_cancel_y : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
 #variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
 #gcode:
-
-## After you uncomment it add your custom values
-
-## You now can use your PAUSE macro direct in your M600 here a short example:
-
-#[gcode_macro M600]
-#description: Filament change
-#gcode: PAUSE X=10 Y=10 Z_MIN=50
-
-## That will park your head front left with a minimum height of 50mm above the bed. If your head
-## is already above 50mm it will use only the z_hop specified with dz.
 
 [virtual_sdcard]
 path: ~/printer_data/gcodes
@@ -66,9 +57,17 @@ gcode:
                  else False if client.park_at_cancel is not defined
                  else True  if client.park_at_cancel|lower == 'true'
                  else False %}
-  {% set retract      = 5.0  if not macro_found else client.cancel_retract|default(5.0)|abs %}
+  {% set retract = 5.0  if not macro_found else client.cancel_retract|default(5.0)|abs %}
+  ##### define park position #####
+  {% set park_x = ""                                    if not macro_found
+             else ""                                    if client.park_at_cancel_x is not defined
+             else "X=" + client.park_at_cancel_x|string if client.park_at_cancel_x is not none %}
+  {% set park_y = ""                                    if not macro_found
+             else ""                                    if client.park_at_cancel_y is not defined
+             else "Y=" + client.park_at_cancel_y|string if client.park_at_cancel_y is not none %}
+  {% set custom_park = True if (park_x|length > 0 or park_y|length > 0) else False %}
   ##### end of definitions #####
-  {% if not printer.pause_resume.is_paused and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {% endif %}
+  {% if (custom_park or not printer.pause_resume.is_paused) and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {park_x} {park_y} {% endif %}
   _CLIENT_RETRACT LENGTH={retract}
   TURN_OFF_HEATERS
   M106 S0
@@ -148,7 +147,7 @@ gcode:
   {% set sp_hop         = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
   {% set sp_move        = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
   ##### get config and toolhead values #####
-  {% set origin   = printer.gcode_move.homing_origin %}
+  {% set origin    = printer.gcode_move.homing_origin %}
   {% set act       = printer.gcode_move.gcode_position %}
   {% set max       = printer.toolhead.axis_maximum %}
   {% set cone      = printer.toolhead.cone_start_z|default(max.z) %} ; height as long the toolhead can reach max and min of an delta
@@ -230,3 +229,4 @@ gcode:
             else client.speed_retract|default(35) %}
 
   _CLIENT_EXTRUDE LENGTH=-{length|float|abs} SPEED={speed|float|abs}
+  


### PR DESCRIPTION
This adds the ability to define a different park position for CANCEL_PRINT.
See the README.md for an example.
Signed-off-by: Alex Zellner alexander.zellner@googlemail.com