### PR TITLE
Lints the markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ gcode:
 
 You can also uncomment all variables if you like. The values are the same as the user default.
 
-##### Different park positon
+##### Different park position
 
 The following descrips how to setup a custom position for CANCEL_PRINT and PAUSE. As an example we asume the bed has asize of (300x300mm) and we want:
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is the new location of the macros and settings provided by the Mainsail team. The intent is to enable all users to setup important macros and settings needed by the mainsail UI.
 
 ### Important features
+
 - Park position depending on printer kinematics or user preference
   - Round beds 0:Ymax
   - Square beds Xmax:Ymax
@@ -12,27 +13,33 @@ This is the new location of the macros and settings provided by the Mainsail tea
   - That is helpful to direct the use of the PAUSE macro in your M600 (see the mainsail.cfg for an example)
 - Customization via a single macro that contains all allowed variables
 - Additional custom variables for stuff like extra retract at CANCEL_PRINT.
-- "Pause at next Layer" and "Pause at Layer #" 
+- "Pause at next Layer" and "Pause at Layer #"
 
 ### Why have we decided to use a dedicated repo?
+
 There are 2 main reasons for that decision
+
 1) The current moonraker changes have shown that we need to react very fast on changes.
 2) We regularly improve the macros and that is the simplest way that the installed base can benefit from it.
 
 ### How to install
+
 We currently do not provide an installer and we might never do. But doing it is simple copy and paste a few commands in an ssh terminal.
 The instructions assume that you have an up to data and working moonraker installation. If not start with updating your moonraker first.
 
-```
+```sh
 cd ~
 git clone https://github.com/mainsail-crew/mainsail-config.git
 ln -sf ~/mainsail-config/mainsail.cfg ~/printer_data/config/mainsail.cfg
 ```
+
 ### Add updater section
+
 You need to update your moonraker.conf to alway get the latest version.
 
-Either open your moonraker.conf and add 
-```
+Either open your moonraker.conf and add
+
+```ini
 [update_manager mainsail-config]
 type: git_repo
 primary_branch: master
@@ -40,30 +47,40 @@ path: ~/mainsail-config
 origin: https://github.com/mainsail-crew/mainsail-config.git
 managed_services: klipper
 ```
+
 below the mainsail updater section.
 
 You can also link and include the prepared file to your moonraker.conf. ssh in your PI and
-```
+
+```sh
 ln -sf ~/mainsail-config/mainsail-moonraker-update.conf ~/printer_data/config/mainsail-moonraker-update.conf
 ```
+
 then open your moonraker.conf and add
-```
+
+```ini
 [include mainsail-moonraker-update.conf]
 ```
+
 below the mainsail updater section.
 
 ### How to setup
-The setup process is still the same, simply add 
-```
+
+The setup process is still the same, simply add
+
+```ini
 [include mainsail.cfg]
 ```
+
 to your printer.cfg file. Be aware the file will show up as read only. This was intended by use.
 
-
 ### How to customize your settings
+
 ##### Different virtual sd card location or a different on_error_gcode
+
 for that simply copy the [virtual_sdcard] block from the mainsail.cfg and simple place it below your include. The result should look similar to:
-```
+
+```ini
 [include mainsail.cfg]
 
 [virtual_sdcard]
@@ -72,11 +89,13 @@ on_error_gcode: CANCEL_PRINT
 ```
 
 ##### Customize macros
+
 We provided a variable setup that let you customize the provided PAUSE, RESUME and CANCEL_PRINT macros. If you need e.g., your own park position simple copy the complete _CLIENT_VARIABLE macro from the mainsail.cfg and place it below your mainsail include.
 After that uncomment the needed variable and fill them with your values.
 
 The result for a custom park position would look like:
-```
+
+```ini
 [include mainsail.cfg]
 
 [gcode_macro _CLIENT_VARIABLE]
@@ -96,16 +115,20 @@ variable_custom_park_y   : 10.0  ; custom y position; value must be within your 
 #variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False] 
 gcode:
 ```
+
 You can also uncomment all variables if you like. The values are the same as the user default.
 
 ##### Differnent park positon
+
 The following descrips how to setup a custom position for CANCEL_PRINT and PAUSE. As an example we asume the bed has asize of (300x300mm) and we want:
-- Position for CANCEL_PRINT: back right (295x295 mm) 
+
+- Position for CANCEL_PRINT: back right (295x295 mm)
 - Position for PAUSE       : front left (10x10 mm)
 
 First copy the complete _CLIENT_VARIABLE macro from the mainsail.cfg and place it below your mainsail include. After that uncomment the needed variables or all. The values are the same as the default.
 After that we need to enter the needed values. See the result below:
-```
+
+```ini
 [include mainsail.cfg]
 
 [gcode_macro _CLIENT_VARIABLE]
@@ -127,27 +150,35 @@ variable_park_at_cancel_y : 295.0 ; different park position during CANCEL_PRINT 
 variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
 gcode:
 ```
+
 This way insures that older configs still work as before.
 
 ### New Feature: "Pause at next Layer" and "Pause at Layer #"
+
 This is based on a idea of Pedro Lamas. It let you add a Pause at the next layer change or if you reach a specific layer number.
 
 First you need to prepare your slicer as described in https://github.com/Klipper3d/klipper/pull/5726
 
-If you done that you can either use 
-```
+If you done that you can either use
+
+```txt
 SET_PAUSE_NEXT_LAYER [MACRO=<name>]
 ```
+
 to get execute the given GCODE macro at the next layer change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
 
-Or use 
-```
+Or use
+
+```txt
 SET_PAUSE_AT_LAYER LAYER=<number> [MACRO=<name>]
 ```
+
 to get execute the given GCODE macro at the given LAYER number change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
 
 To remove the "Pause at Layer" simple send
-```
+
+```txt
 SET_PAUSE_AT_LAYER
 ```
+
 Both will clear after execution.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ gcode:
 
 You can also uncomment all variables if you like. The values are the same as the user default.
 
-##### Differnent park positon
+##### Different park positon
 
 The following descrips how to setup a custom position for CANCEL_PRINT and PAUSE. As an example we asume the bed has asize of (300x300mm) and we want:
 


### PR DESCRIPTION
Just some basic linting of the markdown in README.md (including code block highlighting)