### PR TITLE
feat: adds ENABLE param to SET_PAUSE_AT_LAYER and SET_PAUSE_NEXT_LAYER

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ First you need to prepare your slicer as described in https://github.com/Klipper
 If you done that you can either use
 
 ```txt
-SET_PAUSE_NEXT_LAYER [MACRO=<name>]
+SET_PAUSE_NEXT_LAYER [ENABLE=1] [MACRO=<name>]
 ```
 
 to get execute the given GCODE macro at the next layer change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
@@ -170,15 +170,21 @@ to get execute the given GCODE macro at the next layer change. The MACRO is norm
 Or use
 
 ```txt
-SET_PAUSE_AT_LAYER LAYER=<number> [MACRO=<name>]
+SET_PAUSE_AT_LAYER [ENABLE=1] [LAYER=<number>] [MACRO=<name>]
 ```
 
 to get execute the given GCODE macro at the given LAYER number change. The MACRO is normally either PAUSE (default) or M600 (if you have specified it in your printer.cfg).
 
+To remove the "Pause at next Layer" simple send
+
+```txt
+SET_PAUSE_AT_LAYER ENABLE=0
+```
+
 To remove the "Pause at Layer" simple send
 
 ```txt
-SET_PAUSE_AT_LAYER
+SET_PAUSE_AT_LAYER [ENABLE=0]
 ```
 
 Both will clear after execution.

--- a/client.cfg
+++ b/client.cfg
@@ -72,8 +72,8 @@ gcode:
   TURN_OFF_HEATERS
   M106 S0
   # clear pause_next_layer and pause_at_layer as preparation for next print
-  SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable': False, 'call':"PAUSE"}}"
-  SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer': 0, 'call':"PAUSE"}}"
+  SET_PAUSE_NEXT_LAYER ENABLE=0
+  SET_PAUSE_AT_LAYER ENABLE=0 LAYER=0
   CANCEL_PRINT_BASE
 
 [gcode_macro PAUSE]
@@ -96,36 +96,41 @@ gcode:
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
   
-# Usage: SET_PAUSE_NEXT_LAYER [MACRO=<name>]
+# Usage: SET_PAUSE_NEXT_LAYER [ENABLE=[0|1]] [MACRO=<name>]
 [gcode_macro SET_PAUSE_NEXT_LAYER]
 description: Enable a pause if the next layer is reached
-gcode: SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable':True, 'call':params.MACRO|default("PAUSE")}}"
+gcode:
+  {% set pause_next_layer = printer['gcode_macro SET_PRINT_STATS_INFO'].pause_next_layer %}
+  {% set ENABLE = params.ENABLE | default(1) | int != 0 %}
+  {% set MACRO = params.MACRO | default(pause_next_layer.call, True) %}
+  SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{ 'enable': ENABLE, 'call': MACRO }}"
 
-# Usage: SET_PAUSE_AT_LAYER [LAYER=<number>] [MACRO=<name>]
+# Usage: SET_PAUSE_AT_LAYER [ENABLE=[0|1]] [LAYER=<number>] [MACRO=<name>]
 [gcode_macro SET_PAUSE_AT_LAYER]
 description: Enable/disable a pause if a given layer number is reached
 gcode:
-  {% if params.LAYER is defined %}
-    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': True, 'layer':params.LAYER|int, 'call':params.MACRO|default("PAUSE")}}"
-  {% else %}
-    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer':0, 'call':"PAUSE"}}"
-  {% endif %}
+  {% set pause_at_layer = printer['gcode_macro SET_PRINT_STATS_INFO'].pause_at_layer %}
+  {% set ENABLE = params.ENABLE | int != 0 if params.ENABLE is defined
+             else params.LAYER is defined %}
+  {% set LAYER = params.LAYER | default(pause_at_layer.layer) | int %}
+  {% set MACRO = params.MACRO | default(pause_at_layer.call, True) %}
+  SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{ 'enable': ENABLE, 'layer': LAYER, 'call': MACRO }}"
 
 # Usage: SET_PRINT_STATS_INFO [TOTAL_LAYER=<total_layer_count>] [CURRENT_LAYER= <current_layer>]
 [gcode_macro SET_PRINT_STATS_INFO]
 rename_existing: SET_PRINT_STATS_INFO_BASE
-description: Overwrite, to get pause_next_layer and pause_at_layer feature 
-variable_pause_next_layer: {'enable':False, 'call':"PAUSE"}
-variable_pause_at_layer  : {'enable':False, 'layer':0, 'call':"PAUSE"}
+description: Overwrite, to get pause_next_layer and pause_at_layer feature
+variable_pause_next_layer: { 'enable': False, 'call': "PAUSE" }
+variable_pause_at_layer  : { 'enable': False, 'layer': 0, 'call': "PAUSE" }
 gcode:
   {% if pause_next_layer.enable %}
     {action_respond_info("%s, forced by pause_next_layer" % pause_next_layer.call)}
     {pause_next_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
-    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{'enable': False, 'call':"PAUSE"}}"
+    SET_PAUSE_NEXT_LAYER ENABLE=0
   {% elif pause_at_layer.enable and params.CURRENT_LAYER is defined and params.CURRENT_LAYER|int == pause_at_layer.layer %}
     {action_respond_info("%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer))}
     {pause_at_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
-    SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{'enable': False, 'layer': 0, 'call':"PAUSE"}}"
+    SET_PAUSE_AT_LAYER ENABLE=0
   {% endif %}
   SET_PRINT_STATS_INFO_BASE {rawparams}
   


### PR DESCRIPTION
Adds new `ENABLE` param to both `SET_PAUSE_AT_LAYER` and `SET_PAUSE_NEXT_LAYER`.

This also changes the existing reset to keep all current values, but only set `enable: False` and no other change.