### PR TITLE
Save/Restore extruder temperature on pause/resume

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -80,12 +80,15 @@ gcode:
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
 gcode:
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{printer[printer.toolhead.extruder].target}"
+
   PAUSE_BASE
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
 
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: RESUME_BASE
+variable_last_extruder_temp: 0
 gcode:
   ##### get user parameters or use default #####
   {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
@@ -93,6 +96,9 @@ gcode:
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
   ##### end of definitions #####
+  SET_HEATER_TEMPERATURE HEATER=extruder TARGET={last_extruder_temp}
+  TEMPERATURE_WAIT SENSOR=extruder MINIMUM={last_extruder_temp*0.98} MAXIMUM={last_extruder_temp*1.02}
+
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
   

--- a/client.cfg
+++ b/client.cfg
@@ -96,8 +96,7 @@ gcode:
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
   ##### end of definitions #####
-  SET_HEATER_TEMPERATURE HEATER=extruder TARGET={last_extruder_temp}
-  TEMPERATURE_WAIT SENSOR=extruder MINIMUM={last_extruder_temp*0.98} MAXIMUM={last_extruder_temp*1.02}
+  M109 S{last_extruder_temp}
 
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}


### PR DESCRIPTION
Hi,

Because I can't override the basic gcodes (like pause/resume) from your config a second time I like to add the possibility to cooldown the extruder on idle timeout or manually paused. On resume, the previous extruder temperature is set and the print wait for reaching that temperature bevor starting the next gcodes. If extruder temperature was not changed, nothing happens.

I don't know a scenario where it brakes other things. But in my opinion it is very useful. Especially if for example a filament runout happens, nobody is in the near of the printer. Then the idle timeout happens and the extruder is powered on the whole time. Like to save that energy and the possibility to overheat anything.

In addition, the idle_timout section of the user could look like this
[idle_timeout]
gcode:
  {% if printer.pause_resume.is_paused %}
    {action_respond_info("Extruder powered down on idle timeout.")}
    M117 Idle Timeout, hotend cooldown
    M104 S0  # Set Hot-end to 0C (off)    
  {% else %}
    M117 Idle Timeout, poweroff
    TURN_OFF_HEATERS
    M84
  {% endif %}

Would be nice to merge that. 


Signed-off-by: Frank Roth developer@freakydu.de