### PR TITLE
Simplify variable usage by using default() more heavily

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -51,21 +51,15 @@ description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
   ##### get user parameters or use default #####
-  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
-  {% set allow_park = False if not macro_found
-                 else False if client.park_at_cancel is not defined
-                 else True  if client.park_at_cancel|lower == 'true'
-                 else False %}
-  {% set retract = 5.0  if not macro_found else client.cancel_retract|default(5.0)|abs %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+  {% set allow_park = client.park_at_cancel | default(false) | lower == 'true' %}
+  {% set retract = client.cancel_retract | default(5.0) | abs %}
   ##### define park position #####
-  {% set park_x = ""                                    if not macro_found
-             else ""                                    if client.park_at_cancel_x is not defined
-             else "X=" + client.park_at_cancel_x|string if client.park_at_cancel_x is not none %}
-  {% set park_y = ""                                    if not macro_found
-             else ""                                    if client.park_at_cancel_y is not defined
-             else "Y=" + client.park_at_cancel_y|string if client.park_at_cancel_y is not none %}
-  {% set custom_park = True if (park_x|length > 0 or park_y|length > 0) else False %}
+  {% set park_x = "" if (client.park_at_cancel_x | default(none) is none)
+            else "X=" ~ client.park_at_cancel_x %}
+  {% set park_y = "" if (client.park_at_cancel_y | default(none) is none)
+            else "Y=" ~ client.park_at_cancel_y %}
+  {% set custom_park = park_x | length > 0 or park_y | length > 0 %}
   ##### end of definitions #####
   {% if (custom_park or not printer.pause_resume.is_paused) and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {park_x} {park_y} {% endif %}
   _CLIENT_RETRACT LENGTH={retract}
@@ -91,10 +85,9 @@ rename_existing: RESUME_BASE
 variable_last_extruder_temp: 0
 gcode:
   ##### get user parameters or use default #####
-  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
-  {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
+  {% set sp_move = client.speed_move | default(velocity) %}
   ##### end of definitions #####
   M109 S{last_extruder_temp}
 
@@ -144,18 +137,14 @@ gcode:
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT
 gcode:
   ##### get user parameters or use default #####
-  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
-  {% set use_custom     = False if not macro_found
-                     else False if client.use_custom_pos is not defined
-                     else True  if client.use_custom_pos|lower == 'true'
-                     else False %}
-  {% set custom_park_x  = 0.0 if not macro_found else client.custom_park_x|default(0.0) %}
-  {% set custom_park_y  = 0.0 if not macro_found else client.custom_park_y|default(0.0) %}
-  {% set park_dz        = 2.0 if not macro_found else client.custom_park_dz|default(2.0)|abs %}
-  {% set sp_hop         = 900  if not macro_found else client.speed_hop|default(15) * 60 %}
-  {% set sp_move        = velocity * 60 if not macro_found else client.speed_move|default(velocity) * 60 %}
+  {% set use_custom     = client.use_custom_pos | default(false) | lower == 'true' %}
+  {% set custom_park_x  = client.custom_park_x | default(0.0) %}
+  {% set custom_park_y  = client.custom_park_y | default(0.0) %}
+  {% set park_dz        = client.custom_park_dz | default(2.0) | abs %}
+  {% set sp_hop         = client.speed_hop | default(15) * 60 %}
+  {% set sp_move        = client.speed_move | default(velocity) * 60 %}
   ##### get config and toolhead values #####
   {% set origin    = printer.gcode_move.homing_origin %}
   {% set act       = printer.gcode_move.gcode_position %}
@@ -189,21 +178,10 @@ gcode:
 [gcode_macro _CLIENT_EXTRUDE]
 description: Extrudes, if the extruder is hot enough
 gcode:
-  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
-  {% set use_fw_retract = False if not macro_found
-                     else False if client.use_fw_retract is not defined
-                     else True  if client.use_fw_retract|lower == 'true' and printer.firmware_retraction is defined
-                     else False %}
-
-  {% set length = (params.LENGTH|float) if params.LENGTH is defined
-             else 1.0 if not macro_found
-             else client.unretract|default(1.0) %}
-
-  {% set speed = params.SPEED if params.SPEED is defined
-            else 35 if not macro_found
-            else client.speed_unretract|default(35) %}
-
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+  {% set use_fw_retract = (client.use_fw_retract | default(false) | lower == 'true') and (printer.firmware_retraction is defined) %}
+  {% set length = params.LENGTH | default(client.unretract) | default(1.0) | float %}
+  {% set speed = params.SPEED | default(client.speed_unretract) | default(35) %}
   {% set absolute_extrude = printer.gcode_move.absolute_extrude %}
 
   {% if printer.extruder.can_extrude %}
@@ -227,16 +205,9 @@ gcode:
 [gcode_macro _CLIENT_RETRACT]
 description: Retracts, if the extruder is hot enough
 gcode:
-  {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] %}
-
-  {% set length = (params.LENGTH|float) if params.LENGTH is defined
-             else 1.0 if not macro_found
-             else client.retract|default(1.0) %}
-
-  {% set speed = params.SPEED if params.SPEED is defined
-            else 35 if not macro_found
-            else client.speed_retract|default(35) %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+  {% set length = params.LENGTH | default(client.retract) | default(1.0) | float %}
+  {% set speed = params.SPEED | default(client.speed_retract) | default(35) %}
 
   _CLIENT_EXTRUDE LENGTH=-{length|float|abs} SPEED={speed|float|abs}
   

--- a/client.cfg
+++ b/client.cfg
@@ -51,15 +51,15 @@ description: Cancel the actual running print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
   ##### get user parameters or use default #####
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
-  {% set allow_park = client.park_at_cancel | default(false) | lower == 'true' %}
-  {% set retract = client.cancel_retract | default(5.0) | abs %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
+  {% set allow_park = client.park_at_cancel|default(false)|lower == 'true' %}
+  {% set retract = client.cancel_retract|default(5.0)|abs %}
   ##### define park position #####
-  {% set park_x = "" if (client.park_at_cancel_x | default(none) is none)
+  {% set park_x = "" if (client.park_at_cancel_x|default(none) is none)
             else "X=" ~ client.park_at_cancel_x %}
-  {% set park_y = "" if (client.park_at_cancel_y | default(none) is none)
+  {% set park_y = "" if (client.park_at_cancel_y|default(none) is none)
             else "Y=" ~ client.park_at_cancel_y %}
-  {% set custom_park = park_x | length > 0 or park_y | length > 0 %}
+  {% set custom_park = park_x|length > 0 or park_y|length > 0 %}
   ##### end of definitions #####
   {% if (custom_park or not printer.pause_resume.is_paused) and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {park_x} {park_y} {% endif %}
   _CLIENT_RETRACT LENGTH={retract}
@@ -85,9 +85,9 @@ rename_existing: RESUME_BASE
 variable_last_extruder_temp: 0
 gcode:
   ##### get user parameters or use default #####
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
-  {% set sp_move = client.speed_move | default(velocity) %}
+  {% set sp_move = client.speed_move|default(velocity) %}
   ##### end of definitions #####
   M109 S{last_extruder_temp}
 
@@ -99,8 +99,8 @@ gcode:
 description: Enable a pause if the next layer is reached
 gcode:
   {% set pause_next_layer = printer['gcode_macro SET_PRINT_STATS_INFO'].pause_next_layer %}
-  {% set ENABLE = params.ENABLE | default(1) | int != 0 %}
-  {% set MACRO = params.MACRO | default(pause_next_layer.call, True) %}
+  {% set ENABLE = params.ENABLE|default(1)|int != 0 %}
+  {% set MACRO = params.MACRO|default(pause_next_layer.call, True) %}
   SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_next_layer VALUE="{{ 'enable': ENABLE, 'call': MACRO }}"
 
 # Usage: SET_PAUSE_AT_LAYER [ENABLE=[0|1]] [LAYER=<number>] [MACRO=<name>]
@@ -108,10 +108,10 @@ gcode:
 description: Enable/disable a pause if a given layer number is reached
 gcode:
   {% set pause_at_layer = printer['gcode_macro SET_PRINT_STATS_INFO'].pause_at_layer %}
-  {% set ENABLE = params.ENABLE | int != 0 if params.ENABLE is defined
+  {% set ENABLE = params.ENABLE|int != 0 if params.ENABLE is defined
              else params.LAYER is defined %}
-  {% set LAYER = params.LAYER | default(pause_at_layer.layer) | int %}
-  {% set MACRO = params.MACRO | default(pause_at_layer.call, True) %}
+  {% set LAYER = params.LAYER|default(pause_at_layer.layer)|int %}
+  {% set MACRO = params.MACRO|default(pause_at_layer.call, True) %}
   SET_GCODE_VARIABLE MACRO=SET_PRINT_STATS_INFO VARIABLE=pause_at_layer VALUE="{{ 'enable': ENABLE, 'layer': LAYER, 'call': MACRO }}"
 
 # Usage: SET_PRINT_STATS_INFO [TOTAL_LAYER=<total_layer_count>] [CURRENT_LAYER= <current_layer>]
@@ -137,14 +137,14 @@ gcode:
 description: Helper: park toolhead used in PAUSE and CANCEL_PRINT
 gcode:
   ##### get user parameters or use default #####
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
-  {% set use_custom     = client.use_custom_pos | default(false) | lower == 'true' %}
-  {% set custom_park_x  = client.custom_park_x | default(0.0) %}
-  {% set custom_park_y  = client.custom_park_y | default(0.0) %}
-  {% set park_dz        = client.custom_park_dz | default(2.0) | abs %}
-  {% set sp_hop         = client.speed_hop | default(15) * 60 %}
-  {% set sp_move        = client.speed_move | default(velocity) * 60 %}
+  {% set use_custom     = client.use_custom_pos|default(false)|lower == 'true' %}
+  {% set custom_park_x  = client.custom_park_x|default(0.0) %}
+  {% set custom_park_y  = client.custom_park_y|default(0.0) %}
+  {% set park_dz        = client.custom_park_dz|default(2.0)|abs %}
+  {% set sp_hop         = client.speed_hop|default(15) * 60 %}
+  {% set sp_move        = client.speed_move|default(velocity) * 60 %}
   ##### get config and toolhead values #####
   {% set origin    = printer.gcode_move.homing_origin %}
   {% set act       = printer.gcode_move.gcode_position %}
@@ -178,10 +178,10 @@ gcode:
 [gcode_macro _CLIENT_EXTRUDE]
 description: Extrudes, if the extruder is hot enough
 gcode:
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
-  {% set use_fw_retract = (client.use_fw_retract | default(false) | lower == 'true') and (printer.firmware_retraction is defined) %}
-  {% set length = params.LENGTH | default(client.unretract) | default(1.0) | float %}
-  {% set speed = params.SPEED | default(client.speed_unretract) | default(35) %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
+  {% set use_fw_retract = (client.use_fw_retract|default(false)|lower == 'true') and (printer.firmware_retraction is defined) %}
+  {% set length = params.LENGTH|default(client.unretract)|default(1.0)|float %}
+  {% set speed = params.SPEED|default(client.speed_unretract)|default(35) %}
   {% set absolute_extrude = printer.gcode_move.absolute_extrude %}
 
   {% if printer.extruder.can_extrude %}
@@ -205,9 +205,9 @@ gcode:
 [gcode_macro _CLIENT_RETRACT]
 description: Retracts, if the extruder is hot enough
 gcode:
-  {% set client = printer['gcode_macro _CLIENT_VARIABLE'] | default({}) %}
-  {% set length = params.LENGTH | default(client.retract) | default(1.0) | float %}
-  {% set speed = params.SPEED | default(client.speed_retract) | default(35) %}
+  {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
+  {% set length = params.LENGTH|default(client.retract)|default(1.0)|float %}
+  {% set speed = params.SPEED|default(client.speed_retract)|default(35) %}
 
   _CLIENT_EXTRUDE LENGTH=-{length|float|abs} SPEED={speed|float|abs}
   


### PR DESCRIPTION
Defaulting the main config variable to an empty dict allows for a much cleaner flow than tracking whether it exists in `macro_found`.