### PR TITLE
fix: Update extruder temp only coming from IDLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ gcode:
     M84
 {% endif %}
 ```
-**Update:** Some users reporting that this feature does intervear with their workflow. Therefor we improved it by
+**Update:** Some users reporting that this feature does interfere with their workflow. Therefor we improved it by
 - The temperature is only restored if you come out of idle_timeout
 - PAUSE gets a new paramter RESTORE [0/1]
   - 1: Thats the default and enables the restore of temperature when comming out of idle_timeout.
@@ -220,8 +220,8 @@ That is helpfull if you use it in e.g a M600 macro where you want to insure that
 
 ```ini
 [gcode_macro M600]
-  description: Filament change
-  gcode: PAUSE X=10 Y=10 Z_MIN=50 RESTORE=0
+description: Filament change
+gcode: PAUSE X=10 Y=10 Z_MIN=50 RESTORE=0
 ```
 
 ### New Feature: change idle_timeout when going in PAUSE

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the new location of the macros and settings provided by the Mainsail tea
 - Additional custom variables for stuff like extra retract at CANCEL_PRINT.
 - "Pause at next Layer" and "Pause at Layer #"
 - Different idle_timeout value when entering PAUSE
+- Supports printer.cfg without any extruder e.g. cnc
 
 ### Why have we decided to use a dedicated repo?
 
@@ -208,6 +209,19 @@ gcode:
     TURN_OFF_HEATERS
     M84
 {% endif %}
+```
+**Update:** Some users reporting that this feature does intervear with their workflow. Therefor we improved it by
+- The temperature is only restored if you come out of idle_timeout
+- PAUSE gets a new paramter RESTORE [0/1]
+  - 1: Thats the default and enables the restore of temperature when comming out of idle_timeout.
+  - 0: The temperature will not restored.
+  
+That is helpfull if you use it in e.g a M600 macro where you want to insure that the temperature is never restored.
+
+```ini
+[gcode_macro M600]
+  description: Filament change
+  gcode: PAUSE X=10 Y=10 Z_MIN=50 RESTORE=0
 ```
 
 ### New Feature: change idle_timeout when going in PAUSE

--- a/client.cfg
+++ b/client.cfg
@@ -84,7 +84,8 @@ gcode:
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set idle_timeout = client.idle_timeout|default(0) %}
   ##### end of definitions #####
-  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE={printer[printer.toolhead.extruder].target}
+  {% set restore = True if params.RESTORE|default(1)|int == 1 else False %}
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': printer[printer.toolhead.extruder].target}}"
   # set a new idle_timeout value
   {% if idle_timeout > 0 %}
     SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=restore_idle_timeout VALUE={printer.configfile.settings.idle_timeout.timeout}
@@ -96,7 +97,7 @@ gcode:
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: RESUME_BASE
-variable_last_extruder_temp: 0
+variable_last_extruder_temp: {'restore': False, 'temp': 0}
 gcode:
   ##### get user parameters or use default #####
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
@@ -107,7 +108,9 @@ gcode:
   {% if printer['gcode_macro PAUSE'].restore_idle_timeout > 0 %}
     SET_IDLE_TIMEOUT TIMEOUT={printer['gcode_macro PAUSE'].restore_idle_timeout}
   {% endif %}
-  M109 S{last_extruder_temp}
+  {% if printer.idle_timeout.state|upper == "IDLE" %}
+    {% if last_extruder_temp.restore %} M109 S{last_extruder_temp.temp} {% endif %}
+  {% endif %}
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
   

--- a/client.cfg
+++ b/client.cfg
@@ -83,9 +83,11 @@ gcode:
   ##### get user parameters or use default ##### 
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set idle_timeout = client.idle_timeout|default(0) %}
+  {% set temp = printer[printer.toolhead.extruder].target if printer.toolhead.extruder != '' else 0%}
+  {% set restore = False if printer.toolhead.extruder == ''
+              else True  if params.RESTORE|default(1)|int == 1 else False %}
   ##### end of definitions #####
-  {% set restore = True if params.RESTORE|default(1)|int == 1 else False %}
-  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': printer[printer.toolhead.extruder].target}}"
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': temp}}"
   # set a new idle_timeout value
   {% if idle_timeout > 0 %}
     SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=restore_idle_timeout VALUE={printer.configfile.settings.idle_timeout.timeout}
@@ -198,28 +200,31 @@ gcode:
 [gcode_macro _CLIENT_EXTRUDE]
 description: Extrudes, if the extruder is hot enough
 gcode:
+  ##### get user parameters or use default #####
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set use_fw_retract = (client.use_fw_retract|default(false)|lower == 'true') and (printer.firmware_retraction is defined) %}
   {% set length = params.LENGTH|default(client.unretract)|default(1.0)|float %}
   {% set speed = params.SPEED|default(client.speed_unretract)|default(35) %}
   {% set absolute_extrude = printer.gcode_move.absolute_extrude %}
-
-  {% if printer.extruder.can_extrude %}
-    {% if use_fw_retract %}
-      {% if length < 0 %}
-        G10
+  ##### end of definitions #####
+  {% if printer.toolhead.extruder != '' %}
+    {% if printer[printer.toolhead.extruder].can_extrude %}
+      {% if use_fw_retract %}
+        {% if length < 0 %}
+          G10
+        {% else %}
+          G11
+        {% endif %}
       {% else %}
-        G11
+        M83
+        G1 E{length} F{(speed|float|abs) * 60}
+        {% if absolute_extrude %}
+          M82
+        {% endif %}
       {% endif %}
     {% else %}
-      M83
-      G1 E{length} F{(speed|float|abs) * 60}
-      {% if absolute_extrude %}
-        M82
-      {% endif %}
+      {action_respond_info("Extruder not hot enough")}
     {% endif %}
-  {% else %}
-    {action_respond_info("Extruder not hot enough")}
   {% endif %}
 
 [gcode_macro _CLIENT_RETRACT]


### PR DESCRIPTION
This allows the macro's to be used in a config without any extruder. It will also restore the extruder temperature only when com
ing out of idle_timeout.

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com