### PR TITLE
feat: Add support of an runout sensor

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -37,6 +37,8 @@
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
 #variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
 #variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+#variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+#                                    Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
 #gcode:
 
 [virtual_sdcard]
@@ -46,6 +48,8 @@ on_error_gcode: CANCEL_PRINT
 [pause_resume]
 
 [display_status]
+
+[respond]
 
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
@@ -105,6 +109,9 @@ gcode:
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move = client.speed_move|default(velocity) %}
+  {% set resume = True if client.runout_sensor|default("") == ""     # no runout
+             else True if not printer[client.runout_sensor].enabled  # sensor is disabled
+             else printer[client.runout_sensor].filament_detected %} # sensor status
   ##### end of definitions #####
   # restore idle_timeout time if needed
   {% if printer['gcode_macro PAUSE'].restore_idle_timeout > 0 %}
@@ -113,8 +120,12 @@ gcode:
   {% if printer.idle_timeout.state|upper == "IDLE" %}
     {% if last_extruder_temp.restore %} M109 S{last_extruder_temp.temp} {% endif %}
   {% endif %}
-  _CLIENT_EXTRUDE
-  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  {% if resume %}
+    _CLIENT_EXTRUDE
+    RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  {% else %}
+    RESPOND TYPE=echo MSG='{"\"%s\" detects no filament, therefor RESUME is not executed" % (client.runout_sensor.split(" "))[1]}'
+  {% endif %}
   
 # Usage: SET_PAUSE_NEXT_LAYER [ENABLE=[0|1]] [MACRO=<name>]
 [gcode_macro SET_PAUSE_NEXT_LAYER]
@@ -144,11 +155,11 @@ variable_pause_next_layer: { 'enable': False, 'call': "PAUSE" }
 variable_pause_at_layer  : { 'enable': False, 'layer': 0, 'call': "PAUSE" }
 gcode:
   {% if pause_next_layer.enable %}
-    {action_respond_info("%s, forced by pause_next_layer" % pause_next_layer.call)}
+    RESPOND TYPE=echo MSG='{"%s, forced by pause_next_layer" % pause_next_layer.call}'
     {pause_next_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
     SET_PAUSE_NEXT_LAYER ENABLE=0
   {% elif pause_at_layer.enable and params.CURRENT_LAYER is defined and params.CURRENT_LAYER|int == pause_at_layer.layer %}
-    {action_respond_info("%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer))}
+    RESPOND TYPE=echo MSG='{"%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer)}'
     {pause_at_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
     SET_PAUSE_AT_LAYER ENABLE=0
   {% endif %}
@@ -194,7 +205,7 @@ gcode:
     G1 X{x_park} Y{y_park} F{sp_move}
     {% if not printer.gcode_move.absolute_coordinates %} G91 {% endif %}
   {% else %}
-    {action_respond_info("Printer not homed")}
+    RESPOND TYPE=echo MSG='Printer not homed'
   {% endif %}
   
 [gcode_macro _CLIENT_EXTRUDE]
@@ -223,7 +234,7 @@ gcode:
         {% endif %}
       {% endif %}
     {% else %}
-      {action_respond_info("Extruder not hot enough")}
+      RESPOND TYPE=echo MSG='Extruder not hot enough'
     {% endif %}
   {% endif %}
 


### PR DESCRIPTION
You now can specify a runout sensor in the config variables.

If it is detect empty it will hinder the execution of RESUME and print a message.