### PR TITLE
Added option to disable motors on cancel

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -20,23 +20,24 @@
 ##
 ## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]
-#variable_use_custom_pos   : False ; use custom park coordinates for x,y [True/False]
-#variable_custom_park_x    : 0.0   ; custom x position; value must be within your defined min and max of X
-#variable_custom_park_y    : 0.0   ; custom y position; value must be within your defined min and max of Y
-#variable_custom_park_dz   : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
-#variable_retract          : 1.0   ; the value to retract while PAUSE
-#variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
-#variable_speed_retract    : 35.0  ; retract speed in mm/s
-#variable_unretract        : 1.0   ; the value to unretract while RESUME
-#variable_speed_unretract  : 35.0  ; unretract speed in mm/s
-#variable_speed_hop        : 15.0  ; z move speed in mm/s
-#variable_speed_move       : 100.0 ; move speed in mm/s
-#variable_park_at_cancel   : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
-#variable_park_at_cancel_x : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
-#variable_park_at_cancel_y : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+#variable_use_custom_pos         : False ; use custom park coordinates for x,y [True/False]
+#variable_custom_park_x          : 0.0   ; custom x position; value must be within your defined min and max of X
+#variable_custom_park_y          : 0.0   ; custom y position; value must be within your defined min and max of Y
+#variable_custom_park_dz         : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
+#variable_retract                : 1.0   ; the value to retract while PAUSE
+#variable_cancel_retract         : 5.0   ; the value to retract while CANCEL_PRINT
+#variable_speed_retract          : 35.0  ; retract speed in mm/s
+#variable_unretract              : 1.0   ; the value to unretract while RESUME
+#variable_speed_unretract        : 35.0  ; unretract speed in mm/s
+#variable_speed_hop              : 15.0  ; z move speed in mm/s
+#variable_speed_move             : 100.0 ; move speed in mm/s
+#variable_park_at_cancel         : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
+#variable_disable_motors_cancel  : False ; disable the motors after executing CANCEL_PRINT [True/False]
+#variable_park_at_cancel_x       : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+#variable_park_at_cancel_y       : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-#variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
-#variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+#variable_use_fw_retract         : False ; use fw_retraction instead of the manual version [True/False]
+#variable_idle_timeout           : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 #gcode:
 
 [virtual_sdcard]
@@ -56,6 +57,7 @@ gcode:
   ##### get user parameters or use default #####
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set allow_park = client.park_at_cancel|default(false)|lower == 'true' %}
+  {% set disable_motors = client.disable_motors_cancel|default(false)|lower == 'true' %}
   {% set retract = client.cancel_retract|default(5.0)|abs %}
   ##### define park position #####
   {% set park_x = "" if (client.park_at_cancel_x|default(none) is none)
@@ -72,6 +74,7 @@ gcode:
   _CLIENT_RETRACT LENGTH={retract}
   TURN_OFF_HEATERS
   M106 S0
+  {% if (disable_motors) %} M84 {%endif%}
   # clear pause_next_layer and pause_at_layer as preparation for next print
   SET_PAUSE_NEXT_LAYER ENABLE=0
   SET_PAUSE_AT_LAYER ENABLE=0 LAYER=0


### PR DESCRIPTION
Added variable to _CLIENT_VARIABLE to select if motors should be disabled after cancelling a print and added if statement to evaluate variable in CANCEL_PRINT.


Note: I am tired of having to add this on every update, I can't remember a single time I cancel a print and not disable motors. its an optional change.