### PR TITLE
Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This is the new location of the macros and settings provided by the Mainsail tea
 - "Pause at next Layer" and "Pause at Layer #"
 - Different idle_timeout value when entering PAUSE
 - Supports printer.cfg without any extruder e.g. cnc
+- Custom macros inside PAUSE/RESUME/CANCEL_PRINT
+- RESUME Safeguard features
+  - Possibility to add a filament runout sensor
+  - Usage of [extruder].min_extrude_temp 
 
 ### Why have we decided to use a dedicated repo?
 
@@ -27,7 +31,7 @@ There are 2 main reasons for that decision
 ### How to install
 
 We currently do not provide an installer and we might never do. But doing it is simple copy and paste a few commands in an ssh terminal.
-The instructions assume that you have an up to data and working moonraker installation. If not start with updating your moonraker first.
+The instructions assume that you have an up-to-data and working moonraker installation. If not start with updating your moonraker first.
 
 ```sh
 cd ~
@@ -104,19 +108,29 @@ The result for a custom park position would look like:
 variable_use_custom_pos  : True  ; use custom park coordinates for x,y [True/False] 
 variable_custom_park_x   : 150.0 ; custom x position; value must be within your defined min and max of X
 variable_custom_park_y   : 10.0  ; custom y position; value must be within your defined min and max of Y
-#variable_custom_park_dz  : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position 
-#variable_retract         : 1.0   ; the value to retract while PAUSE
-#variable_cancel_retract  : 5.0   ; the value to retract while CANCEL_PRINT
-#variable_speed_retract   : 35.0  ; retract speed in mm/s
-#variable_unretract       : 1.0   ; the value to unretract while RESUME
-#variable_speed_unretract : 35.0  ; unretract speed in mm/s
-#variable_speed_hop       : 15.0  ; z move speed in mm/s
-#variable_speed_move      : 100.0 ; move speed in mm/s
-#variable_park_at_cancel  : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True,False]
+#variable_custom_park_dz   : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
+#variable_retract          : 1.0   ; the value to retract while PAUSE
+#variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
+#variable_speed_retract    : 35.0  ; retract speed in mm/s
+#variable_unretract        : 1.0   ; the value to unretract while RESUME
+#variable_speed_unretract  : 35.0  ; unretract speed in mm/s
+#variable_speed_hop        : 15.0  ; z move speed in mm/s
+#variable_speed_move       : 100.0 ; move speed in mm/s
+#variable_park_at_cancel   : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
+#variable_park_at_cancel_x : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+#variable_park_at_cancel_y : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-#variable_use_fw_retract  : False ; use fw_retraction instead of the manual version [True/False]
-#variable_idle_timeout    : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored 
-gcode:
+#variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
+#variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+#variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
+## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
+## Only a single line is supported, please generate a macro if you need more than one entry.
+#variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
+#variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
+#variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
+#gcode:
 ```
 
 You can also uncomment all variables if you like. The values are the same as the user default.
@@ -150,8 +164,16 @@ variable_park_at_cancel   : True  ; allow to move the toolhead to park while exe
 variable_park_at_cancel_x : 295.0 ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 variable_park_at_cancel_y : 295.0 ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 # !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
-variable_use_fw_retract   : False  ; use fw_retraction instead of the manual version [True/False]
-variable_idle_timeout     : 0      ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
+variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+#                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+# !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
+# This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
+# Only a single line is supported, please generate a macro if you need more than one entry.
+variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
+variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
+variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
 gcode:
 ```
 
@@ -198,18 +220,9 @@ Both will clear after execution.
 ### New Feature: Save/Restore extruder temperature on pause/resume
 With commit https://github.com/mainsail-crew/mainsail-config/commit/ea19d723bcfbe3e57cff8a9abae36dc5e6a2d1a9 it is posible to switch off the extruder after entering PAUSE. RESUME will heatup the extruder if needed. That is helpful if you e.g. do a pause because of an runout and are not there. Be aware that doing that might have a negative effect on your print quality. Be aware the bed must be heated all the time!
 The following example shows you how to modify your [idle_timeout] to switch of the extruder in case the idle timeout kicks in.
-```ini
-[idle_timeout]
-gcode:
-  {% if printer.pause_resume.is_paused %}
-    {action_respond_info("Idle Timeout: Extruder powered down")}
-    M104 S0   ; Set Hot-end to 0C (off)
-  {% else %}
-    {action_respond_info("Idle Timeout: Stepper and Heater powered down")}
-    TURN_OFF_HEATERS
-    M84
-{% endif %}
-```
+
+The old [idle_timeout] example is removed please use the newer one below.
+
 **Update:** Some users reporting that this feature does interfere with their workflow. Therefor we improved it by
 - The temperature is only restored if you come out of idle_timeout
 - PAUSE gets a new paramter RESTORE [0/1]
@@ -224,7 +237,28 @@ description: Filament change
 gcode: PAUSE X=10 Y=10 Z_MIN=50 RESTORE=0
 ```
 
-### New Feature: change idle_timeout when going in PAUSE
+**2nd Update:** After I get reports from user's that this does not work I found out that I head a missed an important fact in my thoughts. Any interaction with the printer, e.g. change temperature or use a filament load/unload macro will disable the IDLE state.
+The only solution to solve it is an independent controlled variable.
+For that idle_state is added and that needs to be set in your [idle_timeout]
+```ini
+SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=idle_state VALUE=True
+```
+See the example below:
+```ini
+[idle_timeout]
+gcode:
+  {% if printer.pause_resume.is_paused %}
+    SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=idle_state VALUE=True
+    {action_respond_info("Idle Timeout: Extruder powered down")}
+    M104 S0   ; Set Hot-end to 0C (off)
+  {% else %}
+    {action_respond_info("Idle Timeout: Stepper and Heater powered down")}
+    TURN_OFF_HEATERS
+    M84
+  {% endif %}
+```
+
+### New Feature: Change idle_timeout when going in PAUSE
 Many users falling in the trap of idle_timeout. This module is always activated an will shut down heaters and motors after 10 minutes if the printer is idle.
 Users may detect this behaivior first time after the install a runout sensor and have a runout when they are away of the printer.
 
@@ -251,6 +285,72 @@ The following shows the example to set it to 1h when enetering PAUSE
 #variable_park_at_cancel_y : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
 #variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
-variable_idle_timeout     : 3600  ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+variable_idle_timeout     : 3600   ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+#variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
+## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
+## Only a single line is supported, please generate a macro if you need more than one entry.
+#variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
+#variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
+#variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
 gcode:
 ```
+
+### New Feature: Custom macros inside of PAUSE/RESUME/CANCEL_PRINT
+We are still not sure if that is a good idea, but I understand that many user needing a way to do simple stuff like adding the change of a status led to their PAUSE/RESUME/CANCEL_PRINT macros.
+So please use it with care and test if your macro interferes with the general klipper PAUSE/RESUME/CANCEL_PRINT flows.
+
+As an example lets assume you have a macro that allows you to change a LED based an your status and you have the following GCODE calls:
+```ini
+SET_MY_STATUS_LED STATUS=printing
+SET_MY_STATUS_LED STATUS=pause
+SET_MY_STATUS_LED STATUS=cancel
+```
+To add that the following needs to be added:
+```ini
+[gcode_macro _CLIENT_VARIABLE]
+variable_use_custom_pos   : False ; use custom park coordinates for x,y [True/False]
+variable_custom_park_x    : 0.0   ; custom x position; value must be within your defined min and max of X
+variable_custom_park_y    : 0.0   ; custom y position; value must be within your defined min and max of Y
+variable_custom_park_dz   : 2.0   ; custom dz value; the value in mm to lift the nozzle when move to park position
+variable_retract          : 1.0   ; the value to retract while PAUSE
+variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
+variable_speed_retract    : 35.0  ; retract speed in mm/s
+variable_unretract        : 1.0   ; the value to unretract while RESUME
+variable_speed_unretract  : 35.0  ; unretract speed in mm/s
+variable_speed_hop        : 15.0  ; z move speed in mm/s
+variable_speed_move       : 100.0 ; move speed in mm/s
+variable_park_at_cancel   : False ; allow to move the toolhead to park while execute CANCEL_PRINT [True/False]
+variable_park_at_cancel_x : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+variable_park_at_cancel_y : None  ; different park position during CANCEL_PRINT [None/Position as Float]; park_at_cancel must be True
+# !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
+variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
+variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+#                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+# !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
+# This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
+# Only a single line is supported, please generate a macro if you need more than one entry.
+variable_user_pause_macro : "SET_MY_STATUS_LED STATUS=pause"    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
+variable_user_resume_macro: "SET_MY_STATUS_LED STATUS=printing" ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
+variable_user_cancel_macro: "SET_MY_STATUS_LED STATUS=cancel"   ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
+gcode:
+```
+That will then execute these 3 GCODE calls at appropriate positions in the 3 macros.
+
+### New Feature: Add a filament runout sensor to abord RESUME
+Many user using filament runout sensors nowadays, so it makes perfect sense to include them in the decision if it is safe to resume a print.
+
+Let’s assume you have the following sensor defined in your printer.cfg:
+```ini
+[filament_switch_sensor filament_sensor]
+...
+```
+To use that sensor following must be added:
+```ini
+[gcode_macro _CLIENT_VARIABLE]
+variable_runout_sensor    : "filament_switch_sensor filament_sensor"    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+gcode:
+```
+The detection state will be ignored if you temporarily disable the sensor.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ variable_custom_park_y   : 10.0  ; custom y position; value must be within your 
 #variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 #variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
 ##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
-## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
-## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
-## Only a single line is supported, please generate a macro if you need more than one entry.
+## !!! Custom macros, please use with care and review the section of the corresponding macro.
+## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
+## Only  single line commands are supported, please create a macro if you need more than one command.
 #variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
 #variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
 #variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
@@ -168,9 +168,9 @@ variable_use_fw_retract   : False ; use fw_retraction instead of the manual vers
 variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
 #                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
-# !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
-# This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
-# Only a single line is supported, please generate a macro if you need more than one entry.
+## !!! Custom macros, please use with care and review the section of the corresponding macro.
+## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
+## Only  single line commands are supported, please create a macro if you need more than one command.
 variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
 variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
 variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
@@ -288,9 +288,9 @@ The following shows the example to set it to 1h when enetering PAUSE
 variable_idle_timeout     : 3600   ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 #variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
 ##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
-## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
-## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
-## Only a single line is supported, please generate a macro if you need more than one entry.
+## !!! Custom macros, please use with care and review the section of the corresponding macro.
+## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
+## Only  single line commands are supported, please create a macro if you need more than one command.
 #variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
 #variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
 #variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
@@ -329,9 +329,9 @@ variable_use_fw_retract   : False ; use fw_retraction instead of the manual vers
 variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
 #                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
-# !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
-# This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
-# Only a single line is supported, please generate a macro if you need more than one entry.
+## !!! Custom macros, please use with care and review the section of the corresponding macro.
+## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
+## Only  single line commands are supported, please create a macro if you need more than one command.
 variable_user_pause_macro : "SET_MY_STATUS_LED STATUS=pause"    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
 variable_user_resume_macro: "SET_MY_STATUS_LED STATUS=printing" ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
 variable_user_cancel_macro: "SET_MY_STATUS_LED STATUS=cancel"   ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ description: Filament change
 gcode: PAUSE X=10 Y=10 Z_MIN=50 RESTORE=0
 ```
 
-**2nd Update:** After I get reports from user's that this does not work I found out that I head a missed an important fact in my thoughts. Any interaction with the printer, e.g. change temperature or use a filament load/unload macro will disable the IDLE state.
+**2nd Update:** After I get reports from user's that this does not work, during further debug I found out that I missed an important fact in my thoughts. Any interaction with the printer, e.g. change temperature or use a filament load/unload macro will disable the IDLE state.
 The only solution to solve it is an independent controlled variable.
 For that idle_state is added and that needs to be set in your [idle_timeout]
 ```ini

--- a/client.cfg
+++ b/client.cfg
@@ -38,7 +38,13 @@
 #variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
 #variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 #variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
-#                                    Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
+## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
+## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
+## Only a single line is supported, please generate a macro if you need more than one entry.
+#variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
+#variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
+#variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
 #gcode:
 
 [virtual_sdcard]
@@ -67,13 +73,15 @@ gcode:
   {% set custom_park = park_x|length > 0 or park_y|length > 0 %}
   ##### end of definitions #####
   # restore idle_timeout time if needed
-  {% if printer['gcode_macro PAUSE'].restore_idle_timeout > 0 %}
-    SET_IDLE_TIMEOUT TIMEOUT={printer['gcode_macro PAUSE'].restore_idle_timeout}
+  {% if printer['gcode_macro RESUME'].restore_idle_timeout > 0 %}
+    SET_IDLE_TIMEOUT TIMEOUT={printer['gcode_macro RESUME'].restore_idle_timeout}
   {% endif %}
   {% if (custom_park or not printer.pause_resume.is_paused) and allow_park %} _TOOLHEAD_PARK_PAUSE_CANCEL {park_x} {park_y} {% endif %}
   _CLIENT_RETRACT LENGTH={retract}
   TURN_OFF_HEATERS
   M106 S0
+  {client.user_cancel_macro|default("")}
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=idle_state VALUE=False
   # clear pause_next_layer and pause_at_layer as preparation for next print
   SET_PAUSE_NEXT_LAYER ENABLE=0
   SET_PAUSE_AT_LAYER ENABLE=0 LAYER=0
@@ -82,49 +90,67 @@ gcode:
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
-variable_restore_idle_timeout: 0
 gcode:
   ##### get user parameters or use default ##### 
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set idle_timeout = client.idle_timeout|default(0) %}
-  {% set temp = printer[printer.toolhead.extruder].target if printer.toolhead.extruder != '' else 0%}
+  {% set temp = printer[printer.toolhead.extruder].target if printer.toolhead.extruder != '' else 0 %}
   {% set restore = False if printer.toolhead.extruder == ''
               else True  if params.RESTORE|default(1)|int == 1 else False %}
   ##### end of definitions #####
   SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': temp}}"
   # set a new idle_timeout value
   {% if idle_timeout > 0 %}
-    SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=restore_idle_timeout VALUE={printer.configfile.settings.idle_timeout.timeout}
+    SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=restore_idle_timeout VALUE={printer.configfile.settings.idle_timeout.timeout}
     SET_IDLE_TIMEOUT TIMEOUT={idle_timeout}
   {% endif %}
   PAUSE_BASE
+  {client.user_pause_macro|default("")}
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
 
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: RESUME_BASE
 variable_last_extruder_temp: {'restore': False, 'temp': 0}
+variable_restore_idle_timeout: 0
+variable_idle_state: False
 gcode:
   ##### get user parameters or use default #####
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move = client.speed_move|default(velocity) %}
-  {% set resume = True if client.runout_sensor|default("") == ""     # no runout
-             else True if not printer[client.runout_sensor].enabled  # sensor is disabled
-             else printer[client.runout_sensor].filament_detected %} # sensor status
+  {% set runout_resume = True if client.runout_sensor|default("") == ""     # no runout
+                    else True if not printer[client.runout_sensor].enabled  # sensor is disabled
+                    else printer[client.runout_sensor].filament_detected %} # sensor status
+  {% set do_resume = False %}
   ##### end of definitions #####
-  # restore idle_timeout time if needed
-  {% if printer['gcode_macro PAUSE'].restore_idle_timeout > 0 %}
-    SET_IDLE_TIMEOUT TIMEOUT={printer['gcode_macro PAUSE'].restore_idle_timeout}
-  {% endif %}
-  {% if printer.idle_timeout.state|upper == "IDLE" %}
-    {% if last_extruder_temp.restore %} M109 S{last_extruder_temp.temp} {% endif %}
-  {% endif %}
-  {% if resume %}
-    _CLIENT_EXTRUDE
-    RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  #### Printer comming from timeout idle state ####
+  {% if printer.idle_timeout.state|upper == "IDLE" or idle_state %}
+    SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=idle_state VALUE=False
+    {% if last_extruder_temp.restore %}
+      RESPOND TYPE=echo MSG='{"Restore \"%s\" temperature" % printer.toolhead.extruder}'
+      M109 S{last_extruder_temp.temp}
+      {% set do_resume = True %}
+    {% elif printer[printer.toolhead.extruder].can_extrude %}
+      {% set do_resume = True %}
+    {% else %} 
+      RESPOND TYPE=echo MSG='{"IDLE Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
+    {% endif %}
+  #### Printer comming out of regular PAUSE state ####
+  {% elif printer[printer.toolhead.extruder].can_extrude %}
+    {% set do_resume = True %}
   {% else %}
-    RESPOND TYPE=echo MSG='{"\"%s\" detects no filament, therefor RESUME is not executed" % (client.runout_sensor.split(" "))[1]}'
+    RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
+  {% endif %}
+  {% if runout_resume %}
+    {% if do_resume %}
+      {% if restore_idle_timeout > 0 %} SET_IDLE_TIMEOUT TIMEOUT={restore_idle_timeout} {% endif %} # restore idle_timeout time
+      {client.user_resume_macro|default("")}
+      _CLIENT_EXTRUDE
+      RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+    {% endif %}
+  {% else %}
+    RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" detects no filament" % (client.runout_sensor.split(" "))[1]|capitalize}'
   {% endif %}
   
 # Usage: SET_PAUSE_NEXT_LAYER [ENABLE=[0|1]] [MACRO=<name>]
@@ -234,7 +260,7 @@ gcode:
         {% endif %}
       {% endif %}
     {% else %}
-      RESPOND TYPE=echo MSG='Extruder not hot enough'
+      RESPOND TYPE=echo MSG='{"\"%s\" not hot enough" % printer.toolhead.extruder}'
     {% endif %}
   {% endif %}
 

--- a/client.cfg
+++ b/client.cfg
@@ -122,6 +122,8 @@ gcode:
   {% set runout_resume = True if client.runout_sensor|default("") == ""     # no runout
                     else True if not printer[client.runout_sensor].enabled  # sensor is disabled
                     else printer[client.runout_sensor].filament_detected %} # sensor status
+  {% set can_extrude = True if printer.toolhead.extruder == ''           # no extruder defined in config
+                  else printer[printer.toolhead.extruder].can_extrude %} # status of active extruder
   {% set do_resume = False %}
   ##### end of definitions #####
   #### Printer comming from timeout idle state ####
@@ -131,13 +133,13 @@ gcode:
       RESPOND TYPE=echo MSG='{"Restore \"%s\" temperature" % printer.toolhead.extruder}'
       M109 S{last_extruder_temp.temp}
       {% set do_resume = True %}
-    {% elif printer[printer.toolhead.extruder].can_extrude %}
+    {% elif can_extrude %}
       {% set do_resume = True %}
     {% else %} 
       RESPOND TYPE=echo MSG='{"IDLE Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
     {% endif %}
   #### Printer comming out of regular PAUSE state ####
-  {% elif printer[printer.toolhead.extruder].can_extrude %}
+  {% elif can_extrude %}
     {% set do_resume = True %}
   {% else %}
     RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'

--- a/client.cfg
+++ b/client.cfg
@@ -130,19 +130,20 @@ gcode:
   {% if printer.idle_timeout.state|upper == "IDLE" or idle_state %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=idle_state VALUE=False
     {% if last_extruder_temp.restore %}
-      RESPOND TYPE=echo MSG='{"Restore \"%s\" temperature" % printer.toolhead.extruder}'
+      # we need to use the unicode (\u00B0) for the ° as py2 env's would throw an error otherwise 
+      RESPOND TYPE=echo MSG='{"Restoring \"%s\" temperature to %3.1f\u00B0C, this may take some time" % (printer.toolhead.extruder, last_extruder_temp.temp) }'
       M109 S{last_extruder_temp.temp}
       {% set do_resume = True %}
     {% elif can_extrude %}
       {% set do_resume = True %}
     {% else %} 
-      RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
+      RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat up again and press RESUME" % printer.toolhead.extruder}'
     {% endif %}
   #### Printer comming out of regular PAUSE state ####
   {% elif can_extrude %}
     {% set do_resume = True %}
   {% else %}
-    RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
+    RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat up again and press RESUME" % printer.toolhead.extruder}'
   {% endif %}
   {% if runout_resume %}
     {% if do_resume %}
@@ -152,7 +153,7 @@ gcode:
       RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
     {% endif %}
   {% else %}
-    RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" detects no filament" % (client.runout_sensor.split(" "))[1]|capitalize}'
+    RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" detects no filament, please load filament and press RESUME" % (client.runout_sensor.split(" "))[1]}'
   {% endif %}
   
 # Usage: SET_PAUSE_NEXT_LAYER [ENABLE=[0|1]] [MACRO=<name>]

--- a/client.cfg
+++ b/client.cfg
@@ -136,7 +136,7 @@ gcode:
     {% elif can_extrude %}
       {% set do_resume = True %}
     {% else %} 
-      RESPOND TYPE=echo MSG='{"IDLE Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
+      RESPOND TYPE=echo MSG='{"Resume aborted !!! \"%s\" not hot enough, please heat it and press RESUME again" % printer.toolhead.extruder}'
     {% endif %}
   #### Printer comming out of regular PAUSE state ####
   {% elif can_extrude %}

--- a/client.cfg
+++ b/client.cfg
@@ -37,6 +37,8 @@
 ## !!! Caution [firmware_retraction] must be defined in the printer.cfg if you set use_fw_retract: True !!!
 #variable_use_fw_retract   : False ; use fw_retraction instead of the manual version [True/False]
 #variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
+#variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
+#                                    Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
 #gcode:
 
 [virtual_sdcard]
@@ -46,6 +48,8 @@ on_error_gcode: CANCEL_PRINT
 [pause_resume]
 
 [display_status]
+
+[respond]
 
 [gcode_macro CANCEL_PRINT]
 description: Cancel the actual running print
@@ -105,6 +109,9 @@ gcode:
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move = client.speed_move|default(velocity) %}
+  {% set resume = True if client.runout_sensor|default("") == ""     # no runout
+             else True if not printer[client.runout_sensor].enabled  # sensor is disabled
+             else printer[client.runout_sensor].filament_detected %} # sensor status
   ##### end of definitions #####
   # restore idle_timeout time if needed
   {% if printer['gcode_macro PAUSE'].restore_idle_timeout > 0 %}
@@ -113,8 +120,12 @@ gcode:
   {% if printer.idle_timeout.state|upper == "IDLE" %}
     {% if last_extruder_temp.restore %} M109 S{last_extruder_temp.temp} {% endif %}
   {% endif %}
-  _CLIENT_EXTRUDE
-  RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  {% if resume %}
+    _CLIENT_EXTRUDE
+    RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+  {% else %}
+    RESPOND TYPE=echo MSG='{"\"%s\" detects no filament, therefor RESUME is not executed" % (client.runout_sensor.split(" "))[1]}'
+  {% endif %}
   
 # Usage: SET_PAUSE_NEXT_LAYER [ENABLE=[0|1]] [MACRO=<name>]
 [gcode_macro SET_PAUSE_NEXT_LAYER]
@@ -144,11 +155,11 @@ variable_pause_next_layer: { 'enable': False, 'call': "PAUSE" }
 variable_pause_at_layer  : { 'enable': False, 'layer': 0, 'call': "PAUSE" }
 gcode:
   {% if pause_next_layer.enable %}
-    {action_respond_info("%s, forced by pause_next_layer" % pause_next_layer.call)}
+    RESPOND TYPE=echo MSG='{"%s, forced by pause_next_layer" % pause_next_layer.call}'
     {pause_next_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
     SET_PAUSE_NEXT_LAYER ENABLE=0
   {% elif pause_at_layer.enable and params.CURRENT_LAYER is defined and params.CURRENT_LAYER|int == pause_at_layer.layer %}
-    {action_respond_info("%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer))}
+    RESPOND TYPE=echo MSG='{"%s, forced by pause_at_layer [%d]" % (pause_at_layer.call, pause_at_layer.layer)}'
     {pause_at_layer.call} ; execute the given gcode to pause, should be either M600 or PAUSE
     SET_PAUSE_AT_LAYER ENABLE=0
   {% endif %}
@@ -194,7 +205,7 @@ gcode:
     G1 X{x_park} Y{y_park} F{sp_move}
     {% if not printer.gcode_move.absolute_coordinates %} G91 {% endif %}
   {% else %}
-    {action_respond_info("Printer not homed")}
+    RESPOND TYPE=echo MSG='Printer not homed'
   {% endif %}
   
 [gcode_macro _CLIENT_EXTRUDE]
@@ -223,7 +234,7 @@ gcode:
         {% endif %}
       {% endif %}
     {% else %}
-      {action_respond_info("Extruder not hot enough")}
+      RESPOND TYPE=echo MSG='Extruder not hot enough'
     {% endif %}
   {% endif %}
 

--- a/client.cfg
+++ b/client.cfg
@@ -39,9 +39,9 @@
 #variable_idle_timeout     : 0     ; time in sec until idle_timeout kicks in. Value 0 means that no value will be set or restored
 #variable_runout_sensor    : ""    ; If a sensor is defined, it will be used to cancel the execution of RESUME in case no filament is detected.
 ##                                   Specify the config name of the runout sensor e.g "filament_switch_sensor runout". Hint use the same as in your printer.cfg
-## !!! Custom macros, please use it with care and review the place where it is in the corresponding macro.
-## This is meant for stuff like setting a status LED. Please check that your macro does not interfere with the basic function of the 3 macros.
-## Only a single line is supported, please generate a macro if you need more than one entry.
+## !!! Custom macros, please use with care and review the section of the corresponding macro.
+## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
+## Only  single line commands are supported, please create a macro if you need more than one command.
 #variable_user_pause_macro : ""    ; Everything insight the "" will be executed after the klipper base pause (PAUSE_BASE) function
 #variable_user_resume_macro: ""    ; Everything insight the "" will be executed before the klipper base resume (RESUME_BASE) function
 #variable_user_cancel_macro: ""    ; Everything insight the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function


### PR DESCRIPTION
New Features:
- Custom macros inside PAUSE/RESUME/CANCEL_PRINT
- RESUME Safeguard features
  - Possibility to add a filament runout sensor
  - Usage of [extruder].min_extrude_temp
  
Fixes: 
- Save/Restore extruder temperature on pause/resume
Please read the README.md as that needs a change in the [idle_timeout] gcode section.


Signed-off-by: Alex Zellner [alexander.zellner@googlemail.com](mailto:alexander.zellner@googlemail.com)