### PR TITLE
Update client.cfg

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -43,6 +43,7 @@
 ## These macros are for simple operations like setting a status LED. Please make sure your macro does not interfere with the basic macro functions.
 ## Only  single line commands are supported, please create a macro if you need more than one command.
 #variable_user_pause_macro : ""    ; Everything inside the "" will be executed after the klipper base pause (PAUSE_BASE) function
+#variable_user_pause_macro2 : ""    ; Everything inside the "" will be executed after the mainsail.cfg _TOOLHEAD_PARK_PAUSE_CANCEL function
 #variable_user_resume_macro: ""    ; Everything inside the "" will be executed before the klipper base resume (RESUME_BASE) function
 #variable_user_cancel_macro: ""    ; Everything inside the "" will be executed before the klipper base cancel (CANCEL_PRINT_BASE) function
 #gcode:
@@ -110,6 +111,7 @@ gcode:
   PAUSE_BASE
   {client.user_pause_macro|default("")}
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
+  {client.user_pause_macro2|default("")}
 
 [gcode_macro RESUME]
 description: Resume the actual running print


### PR DESCRIPTION
Add second {client.user_pause_macro2|default("")} to PAUSE macro for allowing nozzle wipe or park macros after _TOOLHEAD_PARK_PAUSE_CANCEL

Resolves issue https://github.com/mainsail-crew/mainsail-config/issues/33