### PR TITLE
refactor: use _CLIENT_LINEAR_MOVE in help macros

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -245,9 +245,8 @@ gcode:
   ##### end of definitions #####
   _CLIENT_RETRACT
   {% if "xyz" in printer.toolhead.homed_axes %}
-    G90
-    G1 Z{z_park} F{sp_hop}
-    G1 X{x_park} Y{y_park} F{sp_move}
+    _CLIENT_LINEAR_MOVE Z={z_park} F={sp_hop} ABSOLUTE=1
+    _CLIENT_LINEAR_MOVE  X={x_park} Y={y_park} F={sp_move} ABSOLUTE=1
     {% if not printer.gcode_move.absolute_coordinates %} G91 {% endif %}
   {% else %}
     RESPOND TYPE=echo MSG='Printer not homed'
@@ -272,11 +271,7 @@ gcode:
           G11
         {% endif %}
       {% else %}
-        M83
-        G1 E{length} F{(speed|float|abs) * 60}
-        {% if absolute_extrude %}
-          M82
-        {% endif %}
+        _CLIENT_LINEAR_MOVE E={length} F={(speed|float|abs) * 60}
       {% endif %}
     {% else %}
       RESPOND TYPE=echo MSG='{"\"%s\" not hot enough" % printer.toolhead.extruder}'

--- a/client.cfg
+++ b/client.cfg
@@ -247,7 +247,6 @@ gcode:
   {% if "xyz" in printer.toolhead.homed_axes %}
     _CLIENT_LINEAR_MOVE Z={z_park} F={sp_hop} ABSOLUTE=1
     _CLIENT_LINEAR_MOVE  X={x_park} Y={y_park} F={sp_move} ABSOLUTE=1
-    {% if not printer.gcode_move.absolute_coordinates %} G91 {% endif %}
   {% else %}
     RESPOND TYPE=echo MSG='Printer not homed'
   {% endif %}


### PR DESCRIPTION
This PR will replace all G1 gcodes with `_CLIENT_LINEAR_MOVE`  in `_TOOLHEAD_PARK_PAUSE_CANCEL` and `_CLIENT_EXTRUDE`.