### PR TITLE
feat: add PAUSE fan control & point_unretract

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -20,19 +20,6 @@
 ##
 ################################################################################
 
-## New macro with new point_unretract variable:
-[gcode_macro point_unretract]
-description: The final mini fill nozzle when toolhead is back to the print pause point.
-gcode:
-    SAVE_GCODE_STATE NAME=point_unretract          # Save all coordinates
-	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
-	M83                                            # Put extruder to Relative
-	G1 E{POINT_UNRETRACT} F180                     # Extrude set value                                    
-	# M117 For clear LCD Display from last message on RESUME print
-	M117
-	RESTORE_GCODE_STATE NAME=point_unretract       # Restore all saved coordinates back
-   
-
 ## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]
 #variable_point_unretract  : 2.0   ; Extrusion length (in mm) for refilling the nozzle at the pause point when RESUME is executed
@@ -109,7 +96,7 @@ gcode:
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
-variable_blower_speed: 0                                                         # **blower: variable for save print speed of blower.
+variable_blower_speed: 0
 gcode:
   ##### get user parameters or use default ##### 
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
@@ -117,8 +104,8 @@ gcode:
   {% set temp = printer[printer.toolhead.extruder].target if printer.toolhead.extruder != '' else 0 %}
   {% set restore = False if printer.toolhead.extruder == ''
               else True  if params.RESTORE|default(1)|int == 1 else False %}
-  {% set fan_speed = ((printer.fan.speed |float|round(2)) * 255) | int %}        # **blower: Save actual print speed of blower.
-  SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=blower_speed VALUE={fan_speed}         # **blower: Write the <fan_speed> value to variable.
+  {% set fan_speed = ((printer.fan.speed |float|round(2)) * 255) | int %}
+  SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=blower_speed VALUE={fan_speed}
   ##### end of definitions #####
   SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': temp}}"
   # set a new idle_timeout value
@@ -129,7 +116,7 @@ gcode:
   PAUSE_BASE
   {client.user_pause_macro|default("")}
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
-  M106 S0                                                                        # **blower: Set blower OFF. 
+  M106 S0
 
 [gcode_macro RESUME]
 description: Resume the actual running print
@@ -149,7 +136,7 @@ gcode:
                   else printer[printer.toolhead.extruder].can_extrude %}         # status of active extruder
   {% set do_resume = False %}
   {% set prompt_txt = [] %}
-  {% set fan_speed = printer["gcode_macro PAUSE"].blower_speed %}                # **blower: Load saved blower speed value.
+  {% set fan_speed = printer["gcode_macro PAUSE"].blower_speed %}
   ##### end of definitions #####
   #### Printer comming from timeout idle state ####
   {% if printer.idle_timeout.state|upper == "IDLE" or idle_state %}
@@ -177,9 +164,9 @@ gcode:
       {% if restore_idle_timeout > 0 %} SET_IDLE_TIMEOUT TIMEOUT={restore_idle_timeout} {% endif %} # restore idle_timeout time
       {client.user_resume_macro|default("")}
       _CLIENT_EXTRUDE
-	  M106 S{fan_speed}                                                            # **blower: Restore blower to previous speed. 
+	  M106 S{fan_speed} 
       RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
-      point_unretract                                                              # **point_unretract: final mini fill nozzle on RESUME
+      point_unretract
     {% endif %}
   {% else %}
     RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" detects no filament, please load filament and press RESUME" % (client.runout_sensor.split(" "))[1]}'
@@ -334,3 +321,17 @@ gcode:
   {% endif %}
   G1 { x_move } { y_move } { z_move } { e_move } { rate }
   RESTORE_GCODE_STATE NAME=_client_movement
+
+## New macro with new point_unretract variable:
+[gcode_macro point_unretract]
+description: The final mini fill nozzle when toolhead is back to the print pause point.
+gcode:
+    SAVE_GCODE_STATE NAME=point_unretract          # Save all coordinates
+	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
+	M83                                            # Put extruder to Relative
+	G1 E{POINT_UNRETRACT} F180                     # Extrude set value                                    
+	# M117 For clear LCD Display from last message on RESUME print
+	M117
+	RESTORE_GCODE_STATE NAME=point_unretract       # Restore all saved coordinates back
+
+ 

--- a/client.cfg
+++ b/client.cfg
@@ -11,15 +11,31 @@
 ##   2) remove the comment mark (#) from all lines
 ##   3) change any value in there to your needs
 ##
-## Use the PAUSE macro direct in your M600:
+## Use the PAUSE macro directly in your M600:
 ##  e.g. with a different park position front left and a minimal height of 50 
 ##    [gcode_macro M600]
 ##    description: Filament change
 ##    gcode: PAUSE X=10 Y=10 Z_MIN=50
-##  Z_MIN will park the toolhead at a minimum of 50 mm above to bed to make it easier for you to swap filament.
+##  Z_MIN will park the toolhead at least 50 mm above the bed, making it easier to swap filament.
 ##
+################################################################################
+
+## New macro with new point_unretract variable:
+[gcode_macro point_unretract]
+description: The final mini fill nozzle when toolhead is back to the print pause point.
+gcode:
+    SAVE_GCODE_STATE NAME=point_unretract          # Save all coordinates
+	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
+	M83                                            # Put extruder to Relative
+	G1 E{POINT_UNRETRACT} F180                     # Extrude set value                                    
+	# M117 For clear LCD Display from last message on RESUME print
+	M117
+	RESTORE_GCODE_STATE NAME=point_unretract       # Restore all saved coordinates back
+   
+
 ## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]
+#variable_point_unretract  : 2.0   ; Extrusion length (in mm) for refilling the nozzle at the pause point when RESUME is executed
 #variable_use_custom_pos   : False ; use custom park coordinates for x,y [True/False]
 #variable_custom_park_x    : 0.0   ; custom x position; value must be within your defined min and max of X
 #variable_custom_park_y    : 0.0   ; custom y position; value must be within your defined min and max of Y
@@ -93,6 +109,7 @@ gcode:
 [gcode_macro PAUSE]
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
+variable_blower_speed: 0                                                         # **blower: variable for save print speed of blower.
 gcode:
   ##### get user parameters or use default ##### 
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
@@ -100,6 +117,8 @@ gcode:
   {% set temp = printer[printer.toolhead.extruder].target if printer.toolhead.extruder != '' else 0 %}
   {% set restore = False if printer.toolhead.extruder == ''
               else True  if params.RESTORE|default(1)|int == 1 else False %}
+  {% set fan_speed = ((printer.fan.speed |float|round(2)) * 255) | int %}        # **blower: Save actual print speed of blower.
+  SET_GCODE_VARIABLE MACRO=PAUSE VARIABLE=blower_speed VALUE={fan_speed}         # **blower: Write the <fan_speed> value to variable.
   ##### end of definitions #####
   SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{{'restore': restore, 'temp': temp}}"
   # set a new idle_timeout value
@@ -110,6 +129,7 @@ gcode:
   PAUSE_BASE
   {client.user_pause_macro|default("")}
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
+  M106 S0                                                                        # **blower: Set blower OFF. 
 
 [gcode_macro RESUME]
 description: Resume the actual running print
@@ -122,13 +142,14 @@ gcode:
   {% set client = printer['gcode_macro _CLIENT_VARIABLE']|default({}) %}
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move = client.speed_move|default(velocity) %}
-  {% set runout_resume = True if client.runout_sensor|default("") == ""     # no runout
-                    else True if not printer[client.runout_sensor].enabled  # sensor is disabled
-                    else printer[client.runout_sensor].filament_detected %} # sensor status
-  {% set can_extrude = True if printer.toolhead.extruder == ''           # no extruder defined in config
-                  else printer[printer.toolhead.extruder].can_extrude %} # status of active extruder
+  {% set runout_resume = True if client.runout_sensor|default("") == ""          # no runout
+                    else True if not printer[client.runout_sensor].enabled       # sensor is disabled
+                    else printer[client.runout_sensor].filament_detected %}      # sensor status
+  {% set can_extrude = True if printer.toolhead.extruder == ''                   # no extruder defined in config
+                  else printer[printer.toolhead.extruder].can_extrude %}         # status of active extruder
   {% set do_resume = False %}
   {% set prompt_txt = [] %}
+  {% set fan_speed = printer["gcode_macro PAUSE"].blower_speed %}                # **blower: Load saved blower speed value.
   ##### end of definitions #####
   #### Printer comming from timeout idle state ####
   {% if printer.idle_timeout.state|upper == "IDLE" or idle_state %}
@@ -156,7 +177,9 @@ gcode:
       {% if restore_idle_timeout > 0 %} SET_IDLE_TIMEOUT TIMEOUT={restore_idle_timeout} {% endif %} # restore idle_timeout time
       {client.user_resume_macro|default("")}
       _CLIENT_EXTRUDE
+	  M106 S{fan_speed}                                                            # **blower: Restore blower to previous speed. 
       RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+      point_unretract                                                              # **point_unretract: final mini fill nozzle on RESUME
     {% endif %}
   {% else %}
     RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" detects no filament, please load filament and press RESUME" % (client.runout_sensor.split(" "))[1]}'

--- a/client.cfg
+++ b/client.cfg
@@ -164,7 +164,7 @@ gcode:
       {% if restore_idle_timeout > 0 %} SET_IDLE_TIMEOUT TIMEOUT={restore_idle_timeout} {% endif %} # restore idle_timeout time
       {client.user_resume_macro|default("")}
       _CLIENT_EXTRUDE
-	  M106 S{fan_speed} 
+      M106 S{fan_speed} 
       RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
       point_unretract
     {% endif %}

--- a/client.cfg
+++ b/client.cfg
@@ -326,12 +326,12 @@ gcode:
 [gcode_macro point_unretract]
 description: The final mini fill nozzle when toolhead is back to the print pause point.
 gcode:
-    SAVE_GCODE_STATE NAME=point_unretract          # Save all coordinates
-	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
-	M83                                            # Put extruder to Relative
-	G1 E{POINT_UNRETRACT} F180                     # Extrude set value                                    
-	# M117 For clear LCD Display from last message on RESUME print
-	M117
-	RESTORE_GCODE_STATE NAME=point_unretract       # Restore all saved coordinates back
+    SAVE_GCODE_STATE NAME=point_unretract
+    {% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
+    M83
+    G1 E{POINT_UNRETRACT} F180                                   
+    # M117 For clear LCD Display from last message on RESUME print
+    M117
+    RESTORE_GCODE_STATE NAME=point_unretract
 
  


### PR DESCRIPTION
- Automatically disables the part cooling fan during PAUSE and restores its previous speed on RESUME
- Adds point_unretract macro for controlled nozzle refill after PAUSE
- Uses user-configurable variable point_unretract