### PR TITLE
Feature: Add point_unretract Macro

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -318,10 +318,10 @@ gcode:
 description: The final mini fill nozzle when toolhead is back to the print pause point.
 gcode:
   SAVE_GCODE_STATE NAME=point_unretract
-	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
-	M83
-	G1 E{POINT_UNRETRACT} F180                                   
-	# M117 Clear LCD Display from last message on RESUME
-	M117
-	RESTORE_GCODE_STATE NAME=point_unretract
+  {% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
+  M83
+  G1 E{POINT_UNRETRACT} F180                                   
+  # M117 Clear LCD Display from last message on RESUME
+  M117
+  RESTORE_GCODE_STATE NAME=point_unretract
  

--- a/client.cfg
+++ b/client.cfg
@@ -28,6 +28,7 @@
 #variable_cancel_retract   : 5.0   ; the value to retract while CANCEL_PRINT
 #variable_speed_retract    : 35.0  ; retract speed in mm/s
 #variable_unretract        : 1.0   ; the value to unretract while RESUME
+#variable_point_unretract  : 2.0   ; Extrusion length (in mm) for nozzle refill at the print pause point during RESUME
 #variable_speed_unretract  : 35.0  ; unretract speed in mm/s
 #variable_speed_hop        : 15.0  ; z move speed in mm/s
 #variable_speed_move       : 100.0 ; move speed in mm/s
@@ -157,6 +158,7 @@ gcode:
       {client.user_resume_macro|default("")}
       _CLIENT_EXTRUDE
       RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
+      point_unretract
     {% endif %}
   {% else %}
     RESPOND TYPE=error MSG='{"Resume aborted !!! \"%s\" detects no filament, please load filament and press RESUME" % (client.runout_sensor.split(" "))[1]}'
@@ -311,3 +313,15 @@ gcode:
   {% endif %}
   G1 { x_move } { y_move } { z_move } { e_move } { rate }
   RESTORE_GCODE_STATE NAME=_client_movement
+
+[gcode_macro point_unretract]
+description: The final mini fill nozzle when toolhead is back to the print pause point.
+gcode:
+  SAVE_GCODE_STATE NAME=point_unretract
+	{% set POINT_UNRETRACT = printer["gcode_macro _CLIENT_VARIABLE"].point_unretract | default(0) | float %}
+	M83
+	G1 E{POINT_UNRETRACT} F180                                   
+	# M117 Clear LCD Display from last message on RESUME
+	M117
+	RESTORE_GCODE_STATE NAME=point_unretract
+ 

--- a/client.cfg
+++ b/client.cfg
@@ -11,12 +11,12 @@
 ##   2) remove the comment mark (#) from all lines
 ##   3) change any value in there to your needs
 ##
-## Use the PAUSE macro direct in your M600:
+## Use the PAUSE macro directly in your M600:
 ##  e.g. with a different park position front left and a minimal height of 50 
 ##    [gcode_macro M600]
 ##    description: Filament change
 ##    gcode: PAUSE X=10 Y=10 Z_MIN=50
-##  Z_MIN will park the toolhead at a minimum of 50 mm above to bed to make it easier for you to swap filament.
+##  Z_MIN will park the toolhead at least 50 mm above the bed, making it easier to swap filament.
 ##
 ## Client variable macro for your printer.cfg
 #[gcode_macro _CLIENT_VARIABLE]


### PR DESCRIPTION
**Why is this needed?**
During a normal `PAUSE`, filament can leak out of the nozzle. When `RESUME` is executed, the printhead moves back to the previous location, but without compensating for the lost material. This often leads to a weak layer connection or even print failure when removing the object from the bed.

With `point_unretract`, a small extrusion is performed after returning to the pause point to ensure seamless layer bonding.

**Advantages:**
✅ Prevents weak layer adhesion after `PAUSE`
✅ Reduces risk of print separation during part removal
✅ Fully configurable via `point_unretract` variable

**Potential Downsides:**
⚠️ If the pause point is on an external surface, it may leave a small visible extrusion blob (default 2mm, adjustable). However, this is usually easy to remove by hand.

**Why this cannot be handled by** `user_resume_macro`**?**
The `user_resume_macro` executes before `RESUME_BASE`, meaning the extrusion would happen before the toolhead moves back to the print position. This would negate the intended effect of refilling exactly at the pause location.

For this reason, `point_unretract` is executed after `RESUME_BASE`, ensuring the filament refill happens precisely in the correct location.